### PR TITLE
fix: SPA fallback rewrites for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
Hitting any non-root path on Vercel directly (e.g. \`/kontakt\`) returned a 404 because the static export only contains \`index.html\`. React Router needs the server to serve \`index.html\` for every path so it can hydrate and resolve client-side routes.

\`vercel.json\` adds a catch-all rewrite. Static assets (\`/assets/...\`) are still served as files — rewrites only apply when no file matches.

## Test plan
- [ ] Merge, wait for Vercel auto-redeploy (~1 min)
- [ ] Visit https://shop-sznyt-design.vercel.app/kontakt directly — should load the contact page
- [ ] Visit /o-nas, /sklep, /regulamin directly — all should load
- [ ] Click \"Skontaktuj się\" on /o-nas — should navigate to /kontakt without 404