### PR TITLE
feat: branded transactional email module + admin new-order alert + vitest

### DIFF
--- a/backend/emails/index.ts
+++ b/backend/emails/index.ts
@@ -1,0 +1,8 @@
+export { sendEmail } from "./sendEmail.ts";
+export { renderOrderConfirmation } from "./renderOrderConfirmation.ts";
+export { renderAdminNewOrder } from "./renderAdminNewOrder.ts";
+export { renderOrderShipped } from "./renderOrderShipped.ts";
+export { renderContactNotification } from "./renderContactNotification.ts";
+export { renderReturnRequest } from "./renderReturnRequest.ts";
+export { renderComplaintRequest } from "./renderComplaintRequest.ts";
+export type { OrderEmailData, OrderLineItem, RenderedEmail, ShippingAddress } from "./types.ts";

--- a/backend/emails/layout.ts
+++ b/backend/emails/layout.ts
@@ -1,0 +1,70 @@
+// Brand chrome shared by every transactional email. Email clients block
+// external stylesheets and webfonts, so everything is inlined and the serif
+// stack degrades to Georgia where Cormorant Garamond is unavailable.
+
+const COLORS = {
+  warmWhite: "#FAFAF8",
+  nearBlack: "#1A1A1A",
+  accent: "#B8965A",
+  secondaryText: "#6B6560",
+  borders: "#E5E2DD",
+};
+
+const SERIF = `'Cormorant Garamond', Georgia, serif`;
+const SANS = `'DM Sans', Helvetica, Arial, sans-serif`;
+
+export function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function formatPln(amount: number): string {
+  return `${amount.toFixed(2).replace(".", ",")} PLN`;
+}
+
+/** Turns plain-text paragraphs into escaped HTML with preserved line breaks. */
+export function textBlockToHtml(value: string): string {
+  return escapeHtml(value).replaceAll("\n", "<br>");
+}
+
+export function wrapHtml({ title, bodyHtml }: { title: string; bodyHtml: string }): string {
+  return `<!doctype html>
+<html lang="pl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+</head>
+<body style="margin:0;padding:0;background-color:${COLORS.warmWhite};">
+  <div style="max-width:560px;margin:0 auto;padding:32px 16px;">
+    <div style="text-align:center;padding:8px 0 24px;">
+      <span style="font-family:${SERIF};font-size:30px;letter-spacing:3px;color:${COLORS.nearBlack};">Sznyt Design</span>
+    </div>
+    <div style="background:#ffffff;border:1px solid ${COLORS.borders};border-top:3px solid ${COLORS.accent};padding:32px 28px;font-family:${SANS};color:${COLORS.nearBlack};font-size:15px;line-height:1.6;">
+      <h1 style="font-family:${SERIF};font-weight:600;font-size:26px;margin:0 0 20px;color:${COLORS.nearBlack};">${escapeHtml(title)}</h1>
+      ${bodyHtml}
+    </div>
+    <div style="text-align:center;padding:20px 0;font-family:${SANS};font-size:12px;color:${COLORS.secondaryText};line-height:1.6;">
+      Sznyt Design — ręcznie robione drewniane ramki<br>
+      <a href="mailto:kontakt@sznytdesign.pl" style="color:${COLORS.accent};text-decoration:none;">kontakt@sznytdesign.pl</a>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+/** Small labelled key/value row used across templates. */
+export function metaRowHtml(label: string, value: string): string {
+  return `<p style="margin:0 0 4px;"><span style="color:${COLORS.secondaryText};">${escapeHtml(label)}:</span> ${escapeHtml(value)}</p>`;
+}
+
+/** Accent-colored section heading inside the card. */
+export function sectionHeadingHtml(text: string): string {
+  return `<h2 style="font-family:${SANS};font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:${COLORS.accent};margin:24px 0 8px;">${escapeHtml(text)}</h2>`;
+}
+
+export const layoutColors = COLORS;

--- a/backend/emails/orderSummary.ts
+++ b/backend/emails/orderSummary.ts
@@ -1,0 +1,108 @@
+// Shared receipt fragments used by the customer confirmation and the admin
+// new-order alert, so both emails always agree on what an order looks like.
+
+import { escapeHtml, formatPln, layoutColors, sectionHeadingHtml } from "./layout.ts";
+import type { OrderEmailData, ShippingAddress } from "./types.ts";
+
+export const PAYMENT_METHOD_LABELS: Record<string, string> = {
+  card: "Karta płatnicza",
+  p24: "Przelewy24",
+  blik: "BLIK",
+};
+
+export const SHIPPING_METHOD_LABELS: Record<string, string> = {
+  paczkomat: "InPost Paczkomat",
+  inpost_kurier: "InPost Kurier",
+  dpd: "DPD Kurier",
+};
+
+export function paymentMethodLabel(method: string | null): string {
+  if (!method) return "—";
+  return PAYMENT_METHOD_LABELS[method] ?? method;
+}
+
+export function shippingMethodLabel(method: string | null): string {
+  if (!method) return "—";
+  return SHIPPING_METHOD_LABELS[method] ?? method;
+}
+
+export function shippingAddressLines(
+  address: ShippingAddress,
+  shippingMethod: string | null,
+): string[] {
+  if (!address) return [];
+  const { firstName, lastName, code, name, street, postalCode, city, phone, email } = address;
+  const lines: string[] = [];
+
+  const fullName = [firstName, lastName].filter(Boolean).join(" ");
+  if (fullName) lines.push(fullName);
+  if (shippingMethod === "paczkomat" && code) {
+    lines.push(`Paczkomat ${code}${name && name !== code ? ` — ${name}` : ""}`);
+  }
+  if (street) lines.push(street);
+  const cityLine = [postalCode, city].filter(Boolean).join(" ");
+  if (cityLine) lines.push(cityLine);
+  if (phone) lines.push(`tel. ${phone}`);
+  if (email) lines.push(email);
+  return lines;
+}
+
+export function orderItemsHtml(data: OrderEmailData): string {
+  const rows = data.items
+    .map(
+      (item) => `<tr>
+        <td style="padding:8px 0;border-bottom:1px solid ${layoutColors.borders};">${escapeHtml(item.name)}</td>
+        <td style="padding:8px 8px;border-bottom:1px solid ${layoutColors.borders};text-align:center;white-space:nowrap;">× ${escapeHtml(item.quantity)}</td>
+        <td style="padding:8px 0;border-bottom:1px solid ${layoutColors.borders};text-align:right;white-space:nowrap;">${formatPln(item.unitPrice)}</td>
+      </tr>`,
+    )
+    .join("");
+
+  return `<table style="width:100%;border-collapse:collapse;font-size:14px;" role="presentation">
+    ${rows}
+    <tr>
+      <td colspan="2" style="padding:12px 0 0;font-weight:600;">Suma</td>
+      <td style="padding:12px 0 0;text-align:right;font-weight:600;white-space:nowrap;color:${layoutColors.accent};">${formatPln(data.total)}</td>
+    </tr>
+  </table>`;
+}
+
+export function orderItemsText(data: OrderEmailData): string {
+  const rows = data.items.map(
+    (item) => `- ${item.name} × ${item.quantity} — ${formatPln(item.unitPrice)}`,
+  );
+  return [...rows, "", `Suma: ${formatPln(data.total)}`].join("\n");
+}
+
+export function orderDetailsHtml(data: OrderEmailData): string {
+  const addressLines = shippingAddressLines(data.shippingAddress, data.shippingMethod);
+  const parts = [
+    sectionHeadingHtml("Zamówione produkty"),
+    orderItemsHtml(data),
+    sectionHeadingHtml("Dostawa"),
+    `<p style="margin:0 0 4px;">${escapeHtml(shippingMethodLabel(data.shippingMethod))}</p>`,
+  ];
+  if (addressLines.length > 0) {
+    parts.push(`<p style="margin:0;">${addressLines.map(escapeHtml).join("<br>")}</p>`);
+  }
+  parts.push(
+    sectionHeadingHtml("Płatność"),
+    `<p style="margin:0;">${escapeHtml(paymentMethodLabel(data.paymentMethod))}</p>`,
+  );
+  return parts.join("\n");
+}
+
+export function orderDetailsText(data: OrderEmailData): string {
+  const addressLines = shippingAddressLines(data.shippingAddress, data.shippingMethod);
+  const sections = [
+    "Zamówione produkty:",
+    orderItemsText(data),
+    "",
+    `Dostawa: ${shippingMethodLabel(data.shippingMethod)}`,
+  ];
+  if (addressLines.length > 0) {
+    sections.push("Adres dostawy:", addressLines.join("\n"));
+  }
+  sections.push(`Metoda płatności: ${paymentMethodLabel(data.paymentMethod)}`);
+  return sections.join("\n");
+}

--- a/backend/emails/renderAdminNewOrder.test.ts
+++ b/backend/emails/renderAdminNewOrder.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { renderAdminNewOrder } from "./renderAdminNewOrder.ts";
+import type { OrderEmailData } from "./types.ts";
+
+const sampleOrder: OrderEmailData = {
+  orderId: 7,
+  items: [
+    { name: "Ramka Orzechowa 21×30", quantity: 1, unitPrice: 189 },
+    { name: "Dostawa — DPD Kurier", quantity: 1, unitPrice: 25 },
+  ],
+  total: 214,
+  shippingMethod: "dpd",
+  shippingAddress: {
+    firstName: "Anna",
+    lastName: "Nowak",
+    street: "ul. Lipowa 12",
+    postalCode: "30-002",
+    city: "Kraków",
+    phone: "500600700",
+    email: "anna@example.com",
+  },
+  paymentMethod: "card",
+  customerEmail: "anna@example.com",
+};
+
+describe("renderAdminNewOrder", () => {
+  const { subject, html, text } = renderAdminNewOrder(sampleOrder);
+
+  it("includes order id and total in the subject", () => {
+    expect(subject).toContain("#7");
+    expect(subject).toContain("214,00 PLN");
+  });
+
+  it.each(["html", "text"] as const)("includes key order data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("#7");
+    expect(output).toContain("anna@example.com"); // customer email
+    expect(output).toContain("Ramka Orzechowa 21×30");
+    expect(output).toContain("189,00 PLN");
+    expect(output).toContain("214,00 PLN");
+    expect(output).toContain("Anna Nowak");
+    expect(output).toContain("ul. Lipowa 12");
+    expect(output).toContain("30-002 Kraków");
+    expect(output).toContain("DPD Kurier");
+    expect(output).toContain("Karta płatnicza");
+  });
+});

--- a/backend/emails/renderAdminNewOrder.ts
+++ b/backend/emails/renderAdminNewOrder.ts
@@ -1,0 +1,30 @@
+import { formatPln, metaRowHtml, wrapHtml } from "./layout.ts";
+import { orderDetailsHtml, orderDetailsText } from "./orderSummary.ts";
+import type { OrderEmailData, RenderedEmail } from "./types.ts";
+
+/** Paid-order alert for the shop owners (recipient: CONTACT_RECIPIENT). */
+export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
+  const subject = `Nowe zamówienie #${data.orderId} — ${formatPln(data.total)}`;
+
+  const html = wrapHtml({
+    title: `Nowe zamówienie #${data.orderId}`,
+    bodyHtml: `
+      ${metaRowHtml("Klient", data.customerEmail ?? "—")}
+      ${orderDetailsHtml(data)}
+      <p style="margin:24px 0 0;">Zamówienie czeka na realizację w panelu administracyjnym.</p>
+    `,
+  });
+
+  const text = [
+    "NOWE ZAMÓWIENIE",
+    "",
+    `Numer zamówienia: #${data.orderId}`,
+    `Klient: ${data.customerEmail ?? "—"}`,
+    "",
+    orderDetailsText(data),
+    "",
+    "Zamówienie czeka na realizację w panelu administracyjnym.",
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/backend/emails/renderComplaintRequest.ts
+++ b/backend/emails/renderComplaintRequest.ts
@@ -1,0 +1,29 @@
+import { metaRowHtml, sectionHeadingHtml, textBlockToHtml, wrapHtml } from "./layout.ts";
+import type { RenderedEmail } from "./types.ts";
+
+export interface ComplaintRequestData {
+  orderNumber: string;
+  name: string;
+  email: string;
+  description: string;
+}
+
+export function renderComplaintRequest(data: ComplaintRequestData): RenderedEmail {
+  const subject = `Reklamacja — zamówienie #${data.orderNumber}`;
+
+  const html = wrapHtml({
+    title: "Zgłoszenie reklamacji",
+    bodyHtml: `
+      ${metaRowHtml("Numer zamówienia", `#${data.orderNumber}`)}
+      ${metaRowHtml("Imię i nazwisko", data.name)}
+      ${metaRowHtml("Email", data.email)}
+      ${sectionHeadingHtml("Opis problemu")}
+      <p style="margin:0;">${textBlockToHtml(data.description)}</p>
+      <p style="margin:24px 0 0;">Klient zostanie poproszony o przesłanie zdjęć jako odpowiedź na ten email.</p>
+    `,
+  });
+
+  const text = `ZGŁOSZENIE REKLAMACJI\n\nNumer zamówienia: #${data.orderNumber}\nImię i nazwisko: ${data.name}\nEmail: ${data.email}\n\nOpis problemu:\n${data.description}\n\nKlient zostanie poproszony o przesłanie zdjęć jako odpowiedź na ten email.`;
+
+  return { subject, html, text };
+}

--- a/backend/emails/renderContactNotification.ts
+++ b/backend/emails/renderContactNotification.ts
@@ -1,0 +1,26 @@
+import { metaRowHtml, sectionHeadingHtml, textBlockToHtml, wrapHtml } from "./layout.ts";
+import type { RenderedEmail } from "./types.ts";
+
+export interface ContactNotificationData {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export function renderContactNotification(data: ContactNotificationData): RenderedEmail {
+  const subject = `Wiadomość od ${data.name} — formularz kontaktowy`;
+
+  const html = wrapHtml({
+    title: "Nowa wiadomość z formularza kontaktowego",
+    bodyHtml: `
+      ${metaRowHtml("Imię", data.name)}
+      ${metaRowHtml("Email", data.email)}
+      ${sectionHeadingHtml("Wiadomość")}
+      <p style="margin:0;">${textBlockToHtml(data.message)}</p>
+    `,
+  });
+
+  const text = `Imię: ${data.name}\nEmail: ${data.email}\n\nWiadomość:\n${data.message}`;
+
+  return { subject, html, text };
+}

--- a/backend/emails/renderOrderConfirmation.test.ts
+++ b/backend/emails/renderOrderConfirmation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderOrderConfirmation } from "./renderOrderConfirmation.ts";
+import type { OrderEmailData } from "./types.ts";
+
+const sampleOrder: OrderEmailData = {
+  orderId: 42,
+  items: [
+    { name: "Ramka Dębowa 30×40", quantity: 2, unitPrice: 149 },
+    { name: "Dostawa — InPost Paczkomat", quantity: 1, unitPrice: 20 },
+  ],
+  total: 318,
+  shippingMethod: "paczkomat",
+  shippingAddress: {
+    firstName: "Jan",
+    lastName: "Kowalski",
+    code: "WAW123",
+    name: "ul. Testowa 1",
+    street: "ul. Domowa 5/7",
+    postalCode: "00-001",
+    city: "Warszawa",
+    phone: "600100200",
+    email: "jan@example.com",
+  },
+  paymentMethod: "blik",
+  customerEmail: "jan@example.com",
+};
+
+describe("renderOrderConfirmation", () => {
+  const { subject, html, text } = renderOrderConfirmation(sampleOrder);
+
+  it("includes the order id in the subject", () => {
+    expect(subject).toContain("#42");
+  });
+
+  it.each(["html", "text"] as const)("includes key order data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("#42");
+    expect(output).toContain("Ramka Dębowa 30×40");
+    expect(output).toContain("2"); // quantity
+    expect(output).toContain("149,00 PLN"); // unit price
+    expect(output).toContain("318,00 PLN"); // grand total
+    expect(output).toContain("Jan Kowalski");
+    expect(output).toContain("WAW123");
+    expect(output).toContain("00-001 Warszawa");
+    expect(output).toContain("InPost Paczkomat");
+    expect(output).toContain("BLIK");
+  });
+
+  it("escapes HTML in user-controlled fields", () => {
+    const { html: escapedHtml } = renderOrderConfirmation({
+      ...sampleOrder,
+      items: [{ name: `Ramka <script>alert("x")</script>`, quantity: 1, unitPrice: 100 }],
+    });
+    expect(escapedHtml).not.toContain("<script>");
+    expect(escapedHtml).toContain("&lt;script&gt;");
+  });
+});

--- a/backend/emails/renderOrderConfirmation.ts
+++ b/backend/emails/renderOrderConfirmation.ts
@@ -1,0 +1,29 @@
+import { wrapHtml } from "./layout.ts";
+import { orderDetailsHtml, orderDetailsText } from "./orderSummary.ts";
+import type { OrderEmailData, RenderedEmail } from "./types.ts";
+
+export function renderOrderConfirmation(data: OrderEmailData): RenderedEmail {
+  const subject = `Potwierdzenie zamówienia #${data.orderId} — Sznyt Design`;
+
+  const html = wrapHtml({
+    title: "Dziękujemy za zamówienie!",
+    bodyHtml: `
+      <p style="margin:0 0 8px;">Twoje zamówienie <strong>#${data.orderId}</strong> zostało opłacone i przekazane do realizacji.</p>
+      ${orderDetailsHtml(data)}
+      <p style="margin:24px 0 0;">Poinformujemy Cię, gdy tylko przesyłka zostanie nadana. W razie pytań po prostu odpowiedz na tę wiadomość.</p>
+    `,
+  });
+
+  const text = [
+    "Dziękujemy za złożenie zamówienia!",
+    "",
+    `Numer zamówienia: #${data.orderId}`,
+    "",
+    orderDetailsText(data),
+    "",
+    "Poinformujemy Cię, gdy przesyłka zostanie nadana.",
+    "Sznyt Design — kontakt@sznytdesign.pl",
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/backend/emails/renderOrderShipped.test.ts
+++ b/backend/emails/renderOrderShipped.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { renderOrderShipped } from "./renderOrderShipped.ts";
+
+describe("renderOrderShipped", () => {
+  const { subject, html, text } = renderOrderShipped({
+    orderId: 13,
+    trackingNumber: "620000123456789012345678",
+    shippingMethod: "paczkomat",
+  });
+
+  it("has the shipped subject", () => {
+    expect(subject).toContain("wysłane");
+    expect(subject).toContain("Sznyt Design");
+  });
+
+  it.each(["html", "text"] as const)("includes key shipping data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("#13");
+    expect(output).toContain("620000123456789012345678");
+    expect(output).toContain("InPost Paczkomat"); // carrier
+  });
+
+  it("falls back to the raw shipping method for unknown carriers", () => {
+    const { text: fallbackText } = renderOrderShipped({
+      orderId: 1,
+      trackingNumber: "ABC",
+      shippingMethod: "poczta_polska",
+    });
+    expect(fallbackText).toContain("poczta_polska");
+  });
+});

--- a/backend/emails/renderOrderShipped.ts
+++ b/backend/emails/renderOrderShipped.ts
@@ -1,0 +1,35 @@
+import { metaRowHtml, wrapHtml } from "./layout.ts";
+import { shippingMethodLabel } from "./orderSummary.ts";
+import type { RenderedEmail } from "./types.ts";
+
+export interface OrderShippedData {
+  orderId: number;
+  trackingNumber: string;
+  shippingMethod: string | null;
+}
+
+export function renderOrderShipped(data: OrderShippedData): RenderedEmail {
+  const subject = "Twoje zamówienie zostało wysłane — Sznyt Design";
+  const carrier = shippingMethodLabel(data.shippingMethod);
+
+  const html = wrapHtml({
+    title: "Twoje zamówienie jest w drodze!",
+    bodyHtml: `
+      <p style="margin:0 0 16px;">Zamówienie <strong>#${data.orderId}</strong> zostało nadane.</p>
+      ${metaRowHtml("Przewoźnik", carrier)}
+      ${metaRowHtml("Numer przesyłki", data.trackingNumber)}
+      <p style="margin:24px 0 0;">Dziękujemy za zakup!</p>
+    `,
+  });
+
+  const text = [
+    `Twoje zamówienie #${data.orderId} zostało wysłane.`,
+    "",
+    `Przewoźnik: ${carrier}`,
+    `Numer przesyłki: ${data.trackingNumber}`,
+    "",
+    "Dziękujemy za zakup!",
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/backend/emails/renderReturnRequest.ts
+++ b/backend/emails/renderReturnRequest.ts
@@ -1,0 +1,30 @@
+import { metaRowHtml, sectionHeadingHtml, textBlockToHtml, wrapHtml } from "./layout.ts";
+import type { RenderedEmail } from "./types.ts";
+
+export interface ReturnRequestData {
+  orderNumber: string;
+  name: string;
+  email: string;
+  reason: string;
+  bankAccount: string;
+}
+
+export function renderReturnRequest(data: ReturnRequestData): RenderedEmail {
+  const subject = `Zwrot towaru — zamówienie #${data.orderNumber}`;
+
+  const html = wrapHtml({
+    title: "Zgłoszenie zwrotu",
+    bodyHtml: `
+      ${metaRowHtml("Numer zamówienia", `#${data.orderNumber}`)}
+      ${metaRowHtml("Imię i nazwisko", data.name)}
+      ${metaRowHtml("Email", data.email)}
+      ${metaRowHtml("Numer konta do zwrotu", data.bankAccount)}
+      ${sectionHeadingHtml("Powód zwrotu")}
+      <p style="margin:0;">${textBlockToHtml(data.reason)}</p>
+    `,
+  });
+
+  const text = `ZGŁOSZENIE ZWROTU\n\nNumer zamówienia: #${data.orderNumber}\nImię i nazwisko: ${data.name}\nEmail: ${data.email}\nNumer konta do zwrotu: ${data.bankAccount}\n\nPowód zwrotu:\n${data.reason}`;
+
+  return { subject, html, text };
+}

--- a/backend/emails/sendEmail.ts
+++ b/backend/emails/sendEmail.ts
@@ -1,0 +1,39 @@
+import nodemailer, { type Transporter } from "nodemailer";
+import type { RenderedEmail } from "./types.ts";
+
+// Created lazily: index.js calls dotenv.config() after its imports resolve,
+// so SMTP_* env vars are not set yet at module-load time.
+let transporter: Transporter | null = null;
+
+function getTransporter(): Transporter {
+  transporter ??= nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT),
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+  return transporter;
+}
+
+export interface SendEmailOptions extends RenderedEmail {
+  to: string;
+  replyTo?: string;
+}
+
+/** The only code path that touches the nodemailer transport. */
+export async function sendEmail({ to, replyTo, subject, html, text }: SendEmailOptions) {
+  if (!process.env.SMTP_HOST) {
+    console.log(`[demo] sendEmail skipped — to=${to} subject=${subject}`);
+    return;
+  }
+  return getTransporter().sendMail({
+    from: process.env.SMTP_USER,
+    to,
+    ...(replyTo ? { replyTo } : {}),
+    subject,
+    html,
+    text,
+  });
+}

--- a/backend/emails/sendEmail.ts
+++ b/backend/emails/sendEmail.ts
@@ -6,9 +6,12 @@ import type { RenderedEmail } from "./types.ts";
 let transporter: Transporter | null = null;
 
 function getTransporter(): Transporter {
+  const port = Number(process.env.SMTP_PORT);
   transporter ??= nodemailer.createTransport({
     host: process.env.SMTP_HOST,
-    port: Number(process.env.SMTP_PORT),
+    port,
+    // 465 is implicit TLS; 587 upgrades via STARTTLS (nodemailer's default).
+    secure: port === 465,
     auth: {
       user: process.env.SMTP_USER,
       pass: process.env.SMTP_PASS,

--- a/backend/emails/types.ts
+++ b/backend/emails/types.ts
@@ -1,0 +1,30 @@
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export interface OrderLineItem {
+  name: string;
+  quantity: number;
+  /** Unit price in PLN (not grosze). */
+  unitPrice: number;
+}
+
+/**
+ * Free-form address captured at checkout. Courier orders carry
+ * firstName/lastName/street/postalCode/city/phone/email; paczkomat orders
+ * additionally carry the point's code and name.
+ */
+export type ShippingAddress = Record<string, string | undefined> | null;
+
+export interface OrderEmailData {
+  orderId: number;
+  items: OrderLineItem[];
+  /** Grand total in PLN, including shipping. */
+  total: number;
+  shippingMethod: string | null;
+  shippingAddress: ShippingAddress;
+  paymentMethod: string | null;
+  customerEmail: string | null;
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,23 +5,22 @@ import express from "express";
 import { PrismaClient } from "./generated/prisma/client.js";
 import { PrismaPg } from "@prisma/adapter-pg";
 import cors from "cors";
-import nodemailer from "nodemailer";
 import Stripe from "stripe";
 import { clerkMiddleware, requireAuth, getAuth } from "@clerk/express";
 import { rateLimit } from "express-rate-limit";
+import {
+  sendEmail,
+  renderOrderConfirmation,
+  renderAdminNewOrder,
+  renderOrderShipped,
+  renderContactNotification,
+  renderReturnRequest,
+  renderComplaintRequest,
+} from "./emails/index.ts";
 
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY)
   : null;
-
-const transporter = nodemailer.createTransport({
-  host: process.env.SMTP_HOST,
-  port: Number(process.env.SMTP_PORT),
-  auth: {
-    user: process.env.SMTP_USER,
-    pass: process.env.SMTP_PASS,
-  },
-});
 
 const isDemoMode = !stripe || !process.env.SMTP_HOST;
 
@@ -30,14 +29,6 @@ const isDemoMode = !stripe || !process.env.SMTP_HOST;
 if (stripe && (!process.env.STRIPE_WEBHOOK_SECRET || !process.env.FRONTEND_URL)) {
   console.error("FATAL: STRIPE_WEBHOOK_SECRET and FRONTEND_URL are required when STRIPE_SECRET_KEY is set.");
   process.exit(1);
-}
-
-async function sendMail(opts) {
-  if (!process.env.SMTP_HOST) {
-    console.log(`[demo] sendMail skipped — to=${opts.to} subject=${opts.subject ?? "(no subject)"}`);
-    return;
-  }
-  return transporter.sendMail({ from: process.env.SMTP_USER, ...opts });
 }
 
 const prisma = new PrismaClient({
@@ -189,14 +180,44 @@ app.post(
           return newOrder;
         });
 
-        try {
-          await sendMail({
-            to: session.customer_details?.email,
-            subject: "Potwierdzenie zamówienia - Sznyt Design",
-            text: `Dziękujemy za złożenie zamówienia!\n\nNumer zamówienia: ${order.id}\nSuma: ${session.amount_total / 100} PLN\n\nSkontaktujemy się wkrótce.`,
-          });
-        } catch (emailErr) {
-          console.error("Błąd wysyłania emaila:", emailErr.message);
+        // Shipping appears as a regular line item, so the receipt shows
+        // delivery cost without special-casing it.
+        const orderEmailData = {
+          orderId: order.id,
+          items: lineItems.data.map((item) => ({
+            name: item.description ?? item.price.product.name,
+            quantity: item.quantity,
+            unitPrice: item.price.unit_amount / 100,
+          })),
+          total: session.amount_total / 100,
+          shippingMethod: order.shippingMethod,
+          shippingAddress: order.shippingAddress,
+          paymentMethod,
+          customerEmail: session.customer_details?.email ?? null,
+        };
+
+        // Each email fails independently — a rejected SMTP send must never
+        // 500 the webhook for an order that's already recorded.
+        if (orderEmailData.customerEmail) {
+          try {
+            await sendEmail({
+              to: orderEmailData.customerEmail,
+              ...renderOrderConfirmation(orderEmailData),
+            });
+          } catch (emailErr) {
+            console.error("Błąd wysyłania emaila:", emailErr.message);
+          }
+        }
+
+        if (process.env.CONTACT_RECIPIENT) {
+          try {
+            await sendEmail({
+              to: process.env.CONTACT_RECIPIENT,
+              ...renderAdminNewOrder(orderEmailData),
+            });
+          } catch (emailErr) {
+            console.error("Błąd wysyłania emaila do admina:", emailErr.message);
+          }
         }
       } catch (err) {
         // P2002 on stripeSessionId = webhook retry for an already-recorded order — safe no-op.
@@ -307,11 +328,10 @@ app.post("/contact", formLimiter, async (req, res) => {
       data: { name, email, message },
     });
     try {
-      await sendMail({
+      await sendEmail({
         to: process.env.CONTACT_RECIPIENT,
         replyTo: email,
-        subject: `Wiadomość od ${name} — formularz kontaktowy`,
-        text: `Imię: ${name}\nEmail: ${email}\n\nWiadomość:\n${message}`,
+        ...renderContactNotification({ name, email, message }),
       });
     } catch (emailErr) {
       console.error("Błąd wysyłania emaila:", emailErr.message);
@@ -446,10 +466,13 @@ app.patch("/orders/:id/fulfillment", requireAuth(), requireAdmin, async (req, re
     // send shipping email when status set to shipped and we have customer email + tracking number
     if (fulfillmentStatus === "shipped" && order.customerEmail && trackingNumber) {
       try {
-        await sendMail({
+        await sendEmail({
           to: order.customerEmail,
-          subject: "Twoje zamówienie zostało wysłane — Sznyt Design",
-          text: `Twoje zamówienie #${order.id} zostało wysłane.\n\nNumer przesyłki: ${trackingNumber}\n\nDziękujemy za zakup!`,
+          ...renderOrderShipped({
+            orderId: order.id,
+            trackingNumber,
+            shippingMethod: order.shippingMethod,
+          }),
         });
       } catch (emailErr) {
         console.error("Błąd wysyłania emaila o wysyłce:", emailErr.message);
@@ -523,11 +546,10 @@ app.post("/zwrot", formLimiter, async (req, res) => {
     return res.status(400).json({ error: "Wszystkie pola są wymagane." });
   }
   try {
-    await sendMail({
+    await sendEmail({
       to: process.env.CONTACT_RECIPIENT,
       replyTo: email,
-      subject: `Zwrot towaru — zamówienie #${orderNumber}`,
-      text: `ZGŁOSZENIE ZWROTU\n\nNumer zamówienia: #${orderNumber}\nImię i nazwisko: ${name}\nEmail: ${email}\nNumer konta do zwrotu: ${bankAccount}\n\nPowód zwrotu:\n${reason}`,
+      ...renderReturnRequest({ orderNumber, name, email, reason, bankAccount }),
     });
     res.json({ ok: true });
   } catch (err) {
@@ -544,11 +566,10 @@ app.post("/reklamacja", formLimiter, async (req, res) => {
     return res.status(400).json({ error: "Wszystkie pola są wymagane." });
   }
   try {
-    await sendMail({
+    await sendEmail({
       to: process.env.CONTACT_RECIPIENT,
       replyTo: email,
-      subject: `Reklamacja — zamówienie #${orderNumber}`,
-      text: `ZGŁOSZENIE REKLAMACJI\n\nNumer zamówienia: #${orderNumber}\nImię i nazwisko: ${name}\nEmail: ${email}\n\nOpis problemu:\n${description}\n\nKlient zostanie poproszony o przesłanie zdjęć jako odpowiedź na ten email.`,
+      ...renderComplaintRequest({ orderNumber, name, email, description }),
     });
     res.json({ ok: true });
   } catch (err) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,8 @@
       },
       "devDependencies": {
         "@types/nodemailer": "^7.0.11",
-        "nodemon": "^3.1.14"
+        "nodemon": "^3.1.14",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@clerk/backend": {
@@ -109,6 +110,40 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -539,11 +574,47 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@prisma/adapter-pg": {
       "version": "7.4.2",
@@ -893,6 +964,270 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -914,6 +1249,42 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -943,6 +1314,119 @@
       "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -986,6 +1470,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -1170,6 +1664,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -1234,6 +1738,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1356,6 +1867,16 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -1446,6 +1967,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -1505,6 +2033,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1512,6 +2050,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2048,6 +2596,267 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -2067,6 +2876,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2178,6 +2997,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2254,6 +3092,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ohash": {
@@ -2421,6 +3273,13 @@
         "split2": "^4.1.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -2443,6 +3302,35 @@
         "confbox": "^0.2.4",
         "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postgres": {
@@ -2705,6 +3593,40 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -2896,6 +3818,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2921,6 +3850,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -2938,6 +3877,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
@@ -2992,6 +3938,81 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -3111,6 +4132,207 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3124,6 +4346,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.js",
     "build": "prisma generate && prisma migrate deploy",
     "seed": "tsx seed.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/nodemailer": "^7.0.11",
-    "nodemon": "^3.1.14"
+    "nodemon": "^3.1.14",
+    "vitest": "^4.1.10"
   }
 }

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+// Without a local config vitest walks up and loads the frontend's vite.config
+// (React plugin and all) — pin the backend suite to its own minimal setup.
+export default defineConfig({
+  test: {
+    include: ["emails/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- New `backend/emails/` module: six pure per-template render functions returning `{ subject, html, text }`, plus a single `sendEmail()` helper that is the only code touching the nodemailer transport (replaces the inline `sendMail()` in index.js). Transport is created lazily because `dotenv.config()` runs after ESM imports resolve.
- **New admin new-order alert** (`renderAdminNewOrder`) fires on every paid order in the Stripe webhook, recipient `CONTACT_RECIPIENT` — closes the launch-blocking gap where nobody was notified of paid orders.
- Customer order-confirmation expanded from a two-line stub into a full receipt: line items with quantities and unit prices (shipping shown as a line item), shipping address, payment method, grand total.
- HTML emails use brand chrome (Cormorant wordmark, accent `#B8965A`, warm-white background) with inline styles only; all user-supplied strings are HTML-escaped. Plain-text fallbacks keep the current copy, extended with the receipt data.
- vitest added to `backend/` (`npm test` → `vitest run`, 11 tests) with a local `vitest.config.ts` so the suite doesn't inherit the frontend's vite config. Tests are co-located and assert key data appears in both `html` and `text`.

## Test plan
- [x] `npm test` in `backend/` — 3 files, 11 tests passing
- [x] Backend boots via `npx tsx index.js`
- [x] Stripe CLI end-to-end: `stripe trigger checkout.session.completed` → webhook 200, backend log shows both sends: customer `Potwierdzenie zamówienia #… — Sznyt Design` and admin `Nowe zamówienie #… — 30,00 PLN` to `CONTACT_RECIPIENT` (run with SMTP disabled so the demo-log path proves firing without sending real mail)
- [x] Optional before merge: send one real order email to yourself and eyeball the HTML in Gmail

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)