### PR TITLE
refactor: extract order-intake module per ADR-0001

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,8 @@ Premium e-commerce shop selling designer wooden picture frames at `sznytdesign.p
 - **Furgonetka** — another shipping aggregator, requires business account. Blocked on registration; out of scope until then.
 - **Cutover** — the coordinated DNS + mail records + production env-var switchover from the WordPress placeholder to the React/Express app.
 - **Soft launch** — going live silently, no marketing, with `noindex`. Brand presentation must be production-quality even though no one is being told.
+- **Order intake** — the module that turns a paid Stripe checkout session into a recorded `Order`: transaction, atomic stock decrement, idempotency. Lives in `backend/orders/`. The Stripe webhook route is its adapter.
+- **Line-item contract** — the agreement between checkout and order intake carried through Stripe: each product line item is stamped with `metadata.productId`; a line item without one (shipping) is skipped when recording `OrderItem`s and decrementing stock.
 
 ## Core entities
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,13 +10,17 @@ import { clerkMiddleware, requireAuth, getAuth } from "@clerk/express";
 import { rateLimit } from "express-rate-limit";
 import {
   sendEmail,
-  renderOrderConfirmation,
-  renderAdminNewOrder,
   renderOrderShipped,
   renderContactNotification,
   renderReturnRequest,
   renderComplaintRequest,
 } from "./emails/index.ts";
+import {
+  buildCheckoutLineItems,
+  paidOrderFactsFromSession,
+  recordPaidOrder,
+  notifyOrderPlaced,
+} from "./orders/index.ts";
 
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY)
@@ -72,19 +76,6 @@ app.use(cors({
 app.use(clerkMiddleware());
 const PORT = process.env.PORT || 3000;
 
-const SHIPPING_COSTS = {
-  paczkomat: 20,
-  inpost_kurier: 25,
-  dpd: 25,
-};
-const FREE_SHIPPING_THRESHOLD = 350;
-
-const SHIPPING_LABELS = {
-  paczkomat: "InPost Paczkomat",
-  inpost_kurier: "InPost Kurier",
-  dpd: "DPD Kurier",
-};
-
 function getRole(req) {
   const { sessionClaims } = getAuth(req);
   return sessionClaims?.metadata?.role ?? null;
@@ -117,6 +108,8 @@ app.post(
       return res.status(400).send(`Webhook error: ${err.message}`);
     }
     if (event.type === "checkout.session.completed") {
+      // This route is the Stripe adapter (ADR-0001): all Stripe I/O happens
+      // here, then plain facts go into the order-intake module.
       try {
         const session = event.data.object;
 
@@ -137,96 +130,19 @@ app.post(
           }
         }
 
-        const order = await prisma.$transaction(async (tx) => {
-          const shippingAddress = session.metadata.shippingAddress
-            ? JSON.parse(session.metadata.shippingAddress)
-            : null;
+        const facts = paidOrderFactsFromSession(session, lineItems.data, paymentMethod);
+        const result = await recordPaidOrder(prisma, facts);
 
-          const newOrder = await tx.order.create({
-            data: {
-              stripeSessionId: session.id,
-              status: "paid",
-              total: session.amount_total / 100,
-              customerEmail: session.customer_details?.email,
-              userId: session.metadata.userId,
-              shippingMethod: session.metadata.shippingMethod || null,
-              shippingAddress,
-              paymentMethod,
-            },
-          });
-
-          for (const item of lineItems.data) {
-            const productId = Number(item.price.product.metadata.productId);
-            if (!productId) continue; // skip shipping line item
-
-            const quantity = item.quantity;
-            const price = item.price.unit_amount / 100;
-
-            await tx.orderItem.create({
-              data: {
-                orderId: newOrder.id,
-                productId,
-                quantity,
-                price,
-              },
-            });
-
-            await tx.product.update({
-              where: { id: productId },
-              data: { stock: { decrement: quantity } },
-            });
-          }
-
-          return newOrder;
-        });
-
-        // Shipping appears as a regular line item, so the receipt shows
-        // delivery cost without special-casing it.
-        const orderEmailData = {
-          orderId: order.id,
-          items: lineItems.data.map((item) => ({
-            name: item.description ?? item.price.product.name,
-            quantity: item.quantity,
-            unitPrice: item.price.unit_amount / 100,
-          })),
-          total: session.amount_total / 100,
-          shippingMethod: order.shippingMethod,
-          shippingAddress: order.shippingAddress,
-          paymentMethod,
-          customerEmail: session.customer_details?.email ?? null,
-        };
-
-        // Each email fails independently — a rejected SMTP send must never
-        // 500 the webhook for an order that's already recorded.
-        if (orderEmailData.customerEmail) {
-          try {
-            await sendEmail({
-              to: orderEmailData.customerEmail,
-              ...renderOrderConfirmation(orderEmailData),
-            });
-          } catch (emailErr) {
-            console.error("Błąd wysyłania emaila:", emailErr.message);
-          }
-        }
-
-        if (process.env.CONTACT_RECIPIENT) {
-          try {
-            await sendEmail({
-              to: process.env.CONTACT_RECIPIENT,
-              ...renderAdminNewOrder(orderEmailData),
-            });
-          } catch (emailErr) {
-            console.error("Błąd wysyłania emaila do admina:", emailErr.message);
-          }
+        // Webhook retry for an already-recorded order — 200 no-op, and
+        // crucially no duplicate emails.
+        if (result.created) {
+          await notifyOrderPlaced(facts, result.order.id);
         }
       } catch (err) {
-        // P2002 on stripeSessionId = webhook retry for an already-recorded order — safe no-op.
-        // Anything else must return 500 so Stripe retries; a swallowed error here
+        // Must return 500 so Stripe retries; a swallowed error here
         // permanently loses a paid order.
-        if (err.code !== "P2002") {
-          console.error("Błąd przetwarzania zamówienia:", err.message);
-          return res.status(500).json({ error: "Order processing failed" });
-        }
+        console.error("Błąd przetwarzania zamówienia:", err.message);
+        return res.status(500).json({ error: "Order processing failed" });
       }
     }
 
@@ -350,70 +266,26 @@ app.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
     }
     const { items, userId, shippingMethod, shippingAddress } = req.body;
 
-    if (!shippingMethod || !SHIPPING_COSTS[shippingMethod]) {
-      return res.status(400).json({ error: "Wybierz metodę dostawy" });
-    }
+    // Fetch the referenced products; all validation and pricing lives in the
+    // order-intake module (server-authoritative — the client only chooses
+    // ids and quantities).
+    const ids = Array.isArray(items)
+      ? items.map((item) => Number(item.id)).filter(Number.isInteger)
+      : [];
+    const products = ids.length
+      ? await prisma.product.findMany({ where: { id: { in: ids } } })
+      : [];
 
-    if (!Array.isArray(items) || items.length === 0) {
-      return res.status(400).json({ error: "Koszyk jest pusty" });
-    }
-
-    // Prices, names and images come from the DB — the client only chooses ids and quantities.
-    const products = await prisma.product.findMany({
-      where: { id: { in: items.map((item) => Number(item.id)) } },
-    });
-    const productsById = new Map(products.map((p) => [p.id, p]));
-
-    const orderLines = [];
-    for (const item of items) {
-      const product = productsById.get(Number(item.id));
-      const quantity = Number(item.quantity);
-      if (!product || !Number.isInteger(quantity) || quantity < 1) {
-        return res.status(400).json({ error: "Nieprawidłowy produkt w koszyku" });
-      }
-      if (quantity > product.stock) {
-        return res.status(409).json({
-          error: `Niewystarczająca ilość produktu „${product.name}" — dostępne sztuki: ${product.stock}`,
-        });
-      }
-      orderLines.push({ product, quantity });
-    }
-
-    const subtotal = orderLines.reduce((sum, line) => sum + line.product.price * line.quantity, 0);
-    const shippingCost = subtotal >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_COSTS[shippingMethod];
-
-    const lineItems = orderLines.map(({ product, quantity }) => ({
-      price_data: {
-        currency: "pln",
-        product_data: {
-          name: product.name,
-          ...(product.imageUrl ? { images: [product.imageUrl] } : {}),
-          metadata: { productId: product.id },
-        },
-        unit_amount: Math.round(product.price * 100),
-      },
-      quantity,
-    }));
-
-    if (shippingCost > 0) {
-      lineItems.push({
-        price_data: {
-          currency: "pln",
-          product_data: {
-            name: `Dostawa — ${SHIPPING_LABELS[shippingMethod]}`,
-            metadata: {},
-          },
-          unit_amount: shippingCost * 100,
-        },
-        quantity: 1,
-      });
+    const result = buildCheckoutLineItems(items, products, shippingMethod);
+    if (!result.ok) {
+      return res.status(result.status).json({ error: result.error });
     }
 
     const customerEmail = shippingAddress?.email || undefined;
 
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card", "p24", "blik"],
-      line_items: lineItems,
+      line_items: result.lineItems,
       mode: "payment",
       customer_email: customerEmail,
       success_url: `${process.env.FRONTEND_URL}/sukces?session_id={CHECKOUT_SESSION_ID}`,

--- a/backend/orders/buildCheckoutLineItems.test.ts
+++ b/backend/orders/buildCheckoutLineItems.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { buildCheckoutLineItems } from "./buildCheckoutLineItems.ts";
+import type { CheckoutProduct } from "./types.ts";
+
+const FRAME: CheckoutProduct = {
+  id: 7,
+  name: "Rama Dębowa 30×40",
+  price: 149.99,
+  stock: 5,
+  imageUrl: "https://example.com/rama.jpg",
+};
+
+const SMALL_FRAME: CheckoutProduct = {
+  id: 8,
+  name: "Rama Jesionowa 21×30",
+  price: 89,
+  stock: 2,
+  imageUrl: null,
+};
+
+describe("buildCheckoutLineItems", () => {
+  it("rejects a missing or unknown shipping method with 400", () => {
+    for (const method of [undefined, null, "", "drone"]) {
+      const result = buildCheckoutLineItems([{ id: 7, quantity: 1 }], [FRAME], method);
+      expect(result).toEqual({ ok: false, status: 400, error: "Wybierz metodę dostawy" });
+    }
+  });
+
+  it("rejects an empty or non-array cart with 400", () => {
+    for (const items of [[], null, undefined, "nope"]) {
+      const result = buildCheckoutLineItems(items, [FRAME], "paczkomat");
+      expect(result).toEqual({ ok: false, status: 400, error: "Koszyk jest pusty" });
+    }
+  });
+
+  it("rejects unknown products and invalid quantities with 400", () => {
+    const cases = [
+      [{ id: 999, quantity: 1 }], // not in DB
+      [{ id: 7, quantity: 0 }],
+      [{ id: 7, quantity: -1 }],
+      [{ id: 7, quantity: 1.5 }],
+      [{ id: 7, quantity: "abc" }],
+    ];
+    for (const items of cases) {
+      const result = buildCheckoutLineItems(items, [FRAME], "paczkomat");
+      expect(result).toEqual({
+        ok: false,
+        status: 400,
+        error: "Nieprawidłowy produkt w koszyku",
+      });
+    }
+  });
+
+  it("rejects a quantity above stock with 409 and names the product", () => {
+    const result = buildCheckoutLineItems([{ id: 8, quantity: 3 }], [SMALL_FRAME], "dpd");
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: `Niewystarczająca ilość produktu „Rama Jesionowa 21×30" — dostępne sztuki: 2`,
+    });
+  });
+
+  it("prices from the DB, stamps metadata.productId, and appends the shipping line", () => {
+    const result = buildCheckoutLineItems(
+      [{ id: 7, quantity: 1 }, { id: 8, quantity: 1 }],
+      [FRAME, SMALL_FRAME],
+      "paczkomat",
+    );
+    if (!result.ok) throw new Error(`expected ok, got ${result.error}`);
+
+    expect(result.subtotal).toBeCloseTo(238.99);
+    expect(result.shippingCost).toBe(20);
+    expect(result.lineItems).toHaveLength(3);
+
+    const [frame, smallFrame, shipping] = result.lineItems;
+    expect(frame.price_data?.product_data?.metadata).toEqual({ productId: "7" });
+    expect(frame.price_data?.unit_amount).toBe(14999); // grosze, rounded
+    expect(frame.price_data?.product_data?.images).toEqual(["https://example.com/rama.jpg"]);
+    expect(smallFrame.price_data?.product_data?.images).toBeUndefined();
+
+    // The line-item contract: the shipping line has no productId, so order
+    // intake will skip it for OrderItems and stock decrement.
+    expect(shipping.price_data?.product_data?.name).toBe("Dostawa — InPost Paczkomat");
+    expect(shipping.price_data?.product_data?.metadata).toEqual({});
+    expect(shipping.price_data?.unit_amount).toBe(2000);
+    expect(shipping.quantity).toBe(1);
+  });
+
+  it("drops the shipping line at or above the free-shipping threshold", () => {
+    const result = buildCheckoutLineItems([{ id: 7, quantity: 3 }], [FRAME], "dpd");
+    if (!result.ok) throw new Error(`expected ok, got ${result.error}`);
+
+    expect(result.subtotal).toBeCloseTo(449.97);
+    expect(result.shippingCost).toBe(0);
+    expect(result.lineItems).toHaveLength(1);
+  });
+
+  it("charges shipping just below the threshold", () => {
+    const cheap: CheckoutProduct = { ...SMALL_FRAME, price: 349.99, stock: 1 };
+    const result = buildCheckoutLineItems([{ id: 8, quantity: 1 }], [cheap], "inpost_kurier");
+    if (!result.ok) throw new Error(`expected ok, got ${result.error}`);
+    expect(result.shippingCost).toBe(25);
+  });
+});

--- a/backend/orders/buildCheckoutLineItems.ts
+++ b/backend/orders/buildCheckoutLineItems.ts
@@ -1,0 +1,88 @@
+import type Stripe from "stripe";
+import type { CartItemInput, CheckoutProduct } from "./types.ts";
+import { SHIPPING_COSTS, SHIPPING_LABELS, FREE_SHIPPING_THRESHOLD } from "./shipping.ts";
+
+export type BuildCheckoutResult =
+  | {
+      ok: true;
+      lineItems: Stripe.Checkout.SessionCreateParams.LineItem[];
+      subtotal: number;
+      shippingCost: number;
+    }
+  | { ok: false; status: 400 | 409; error: string };
+
+/**
+ * Server-authoritative checkout pricing: prices, names and images come from
+ * the DB — the client only chooses ids and quantities. Each product line is
+ * stamped with metadata.productId (the line-item contract); the shipping
+ * line carries no productId so order intake skips it for stock decrement.
+ */
+export function buildCheckoutLineItems(
+  items: unknown,
+  products: CheckoutProduct[],
+  shippingMethod: unknown,
+): BuildCheckoutResult {
+  if (typeof shippingMethod !== "string" || !SHIPPING_COSTS[shippingMethod]) {
+    return { ok: false, status: 400, error: "Wybierz metodę dostawy" };
+  }
+
+  if (!Array.isArray(items) || items.length === 0) {
+    return { ok: false, status: 400, error: "Koszyk jest pusty" };
+  }
+
+  const productsById = new Map(products.map((p) => [p.id, p]));
+
+  const orderLines: { product: CheckoutProduct; quantity: number }[] = [];
+  for (const item of items as CartItemInput[]) {
+    const product = productsById.get(Number(item.id));
+    const quantity = Number(item.quantity);
+    if (!product || !Number.isInteger(quantity) || quantity < 1) {
+      return { ok: false, status: 400, error: "Nieprawidłowy produkt w koszyku" };
+    }
+    if (quantity > product.stock) {
+      return {
+        ok: false,
+        status: 409,
+        error: `Niewystarczająca ilość produktu „${product.name}" — dostępne sztuki: ${product.stock}`,
+      };
+    }
+    orderLines.push({ product, quantity });
+  }
+
+  const subtotal = orderLines.reduce(
+    (sum, line) => sum + line.product.price * line.quantity,
+    0,
+  );
+  const shippingCost =
+    subtotal >= FREE_SHIPPING_THRESHOLD ? 0 : SHIPPING_COSTS[shippingMethod];
+
+  const lineItems: Stripe.Checkout.SessionCreateParams.LineItem[] =
+    orderLines.map(({ product, quantity }) => ({
+      price_data: {
+        currency: "pln",
+        product_data: {
+          name: product.name,
+          ...(product.imageUrl ? { images: [product.imageUrl] } : {}),
+          metadata: { productId: String(product.id) },
+        },
+        unit_amount: Math.round(product.price * 100),
+      },
+      quantity,
+    }));
+
+  if (shippingCost > 0) {
+    lineItems.push({
+      price_data: {
+        currency: "pln",
+        product_data: {
+          name: `Dostawa — ${SHIPPING_LABELS[shippingMethod]}`,
+          metadata: {},
+        },
+        unit_amount: shippingCost * 100,
+      },
+      quantity: 1,
+    });
+  }
+
+  return { ok: true, lineItems, subtotal, shippingCost };
+}

--- a/backend/orders/index.ts
+++ b/backend/orders/index.ts
@@ -1,0 +1,8 @@
+export { buildCheckoutLineItems } from "./buildCheckoutLineItems.ts";
+export { paidOrderFactsFromSession } from "./stripeFacts.ts";
+export { recordPaidOrder } from "./recordPaidOrder.ts";
+export { notifyOrderPlaced } from "./notifyOrderPlaced.ts";
+export { SHIPPING_COSTS, SHIPPING_LABELS, FREE_SHIPPING_THRESHOLD } from "./shipping.ts";
+export type { PaidOrderFacts, PaidLineItem, CheckoutProduct, CartItemInput } from "./types.ts";
+export type { BuildCheckoutResult } from "./buildCheckoutLineItems.ts";
+export type { RecordPaidOrderResult } from "./recordPaidOrder.ts";

--- a/backend/orders/notifyOrderPlaced.ts
+++ b/backend/orders/notifyOrderPlaced.ts
@@ -1,0 +1,52 @@
+import { sendEmail, renderOrderConfirmation, renderAdminNewOrder } from "../emails/index.ts";
+import type { OrderEmailData } from "../emails/types.ts";
+import type { PaidOrderFacts } from "./types.ts";
+
+/**
+ * Best-effort order notifications: customer confirmation + admin new-order
+ * alert. Each email fails independently — a rejected SMTP send must never
+ * propagate for an order that's already recorded, so this function never
+ * throws.
+ */
+export async function notifyOrderPlaced(
+  facts: PaidOrderFacts,
+  orderId: number,
+): Promise<void> {
+  // Shipping appears as a regular line item, so the receipt shows
+  // delivery cost without special-casing it.
+  const emailData: OrderEmailData = {
+    orderId,
+    items: facts.lineItems.map((item) => ({
+      name: item.name,
+      quantity: item.quantity,
+      unitPrice: item.unitPrice,
+    })),
+    total: facts.total,
+    shippingMethod: facts.shippingMethod,
+    shippingAddress: facts.shippingAddress,
+    paymentMethod: facts.paymentMethod,
+    customerEmail: facts.customerEmail,
+  };
+
+  if (emailData.customerEmail) {
+    try {
+      await sendEmail({
+        to: emailData.customerEmail,
+        ...renderOrderConfirmation(emailData),
+      });
+    } catch (emailErr) {
+      console.error("Błąd wysyłania emaila:", (emailErr as Error).message);
+    }
+  }
+
+  if (process.env.CONTACT_RECIPIENT) {
+    try {
+      await sendEmail({
+        to: process.env.CONTACT_RECIPIENT,
+        ...renderAdminNewOrder(emailData),
+      });
+    } catch (emailErr) {
+      console.error("Błąd wysyłania emaila do admina:", (emailErr as Error).message);
+    }
+  }
+}

--- a/backend/orders/recordPaidOrder.db.test.ts
+++ b/backend/orders/recordPaidOrder.db.test.ts
@@ -1,0 +1,113 @@
+/**
+ * DB-backed suite (npm run test:db) — proves the order-intake invariants
+ * against a real Postgres: atomic stock decrement and stripeSessionId
+ * idempotency. One-time setup: `npm run test:db:prepare`.
+ */
+import "dotenv/config"; // vitest doesn't load backend/.env into process.env
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { PrismaClient } from "../generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { recordPaidOrder } from "./recordPaidOrder.ts";
+import type { PaidOrderFacts } from "./types.ts";
+import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+
+let prisma: PrismaClient;
+
+beforeAll(() => {
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
+  );
+});
+
+async function seedProducts() {
+  await prisma.product.createMany({
+    data: [
+      { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 },
+      { name: "Rama Jesionowa 21×30", price: 89, stock: 2 },
+    ],
+  });
+}
+
+function facts(overrides: Partial<PaidOrderFacts> = {}): PaidOrderFacts {
+  return {
+    stripeSessionId: "cs_test_abc",
+    total: 408.98,
+    customerEmail: "klient@example.com",
+    userId: "user_abc",
+    shippingMethod: "paczkomat",
+    shippingAddress: { firstName: "Jan", city: "Kraków" },
+    paymentMethod: "blik",
+    lineItems: [
+      { productId: 1, name: "Rama Dębowa 30×40", quantity: 2, unitPrice: 149.99 },
+      { productId: 2, name: "Rama Jesionowa 21×30", quantity: 1, unitPrice: 89 },
+      { productId: null, name: "Dostawa — InPost Paczkomat", quantity: 1, unitPrice: 20 },
+    ],
+    ...overrides,
+  };
+}
+
+describe("recordPaidOrder", () => {
+  it("creates the order with items and decrements stock, skipping the shipping line", async () => {
+    await seedProducts();
+
+    const result = await recordPaidOrder(prisma, facts());
+    expect(result.created).toBe(true);
+    if (!result.created) return;
+
+    expect(result.order.status).toBe("paid");
+    expect(result.order.total).toBe(408.98);
+    expect(result.order.stripeSessionId).toBe("cs_test_abc");
+
+    const items = await prisma.orderItem.findMany({ orderBy: { productId: "asc" } });
+    expect(items).toHaveLength(2); // shipping line produced no OrderItem
+    expect(items[0]).toMatchObject({ productId: 1, quantity: 2, price: 149.99 });
+    expect(items[1]).toMatchObject({ productId: 2, quantity: 1, price: 89 });
+
+    const products = await prisma.product.findMany({ orderBy: { id: "asc" } });
+    expect(products[0].stock).toBe(3); // 5 - 2
+    expect(products[1].stock).toBe(1); // 2 - 1
+  });
+
+  it("treats a duplicate stripeSessionId as a no-op: no second order, no double decrement", async () => {
+    await seedProducts();
+
+    const first = await recordPaidOrder(prisma, facts());
+    expect(first.created).toBe(true);
+
+    const retry = await recordPaidOrder(prisma, facts());
+    expect(retry).toEqual({ created: false, reason: "duplicate" });
+
+    expect(await prisma.order.count()).toBe(1);
+    const products = await prisma.product.findMany({ orderBy: { id: "asc" } });
+    expect(products[0].stock).toBe(3);
+    expect(products[1].stock).toBe(1);
+  });
+
+  it("rolls back the whole order when any line fails — no partial stock decrement", async () => {
+    await seedProducts();
+
+    const badFacts = facts({
+      lineItems: [
+        { productId: 1, name: "Rama Dębowa 30×40", quantity: 2, unitPrice: 149.99 },
+        { productId: 999, name: "Widmo", quantity: 1, unitPrice: 10 }, // no such product
+      ],
+    });
+
+    await expect(recordPaidOrder(prisma, badFacts)).rejects.toThrow();
+
+    expect(await prisma.order.count()).toBe(0);
+    expect(await prisma.orderItem.count()).toBe(0);
+    const products = await prisma.product.findMany({ orderBy: { id: "asc" } });
+    expect(products[0].stock).toBe(5); // untouched — transaction rolled back
+  });
+});

--- a/backend/orders/recordPaidOrder.ts
+++ b/backend/orders/recordPaidOrder.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient, Order } from "../generated/prisma/client.js";
+import type { PaidOrderFacts } from "./types.ts";
+
+export type RecordPaidOrderResult =
+  | { created: true; order: Order }
+  | { created: false; reason: "duplicate" };
+
+/**
+ * Record a paid order: Order + OrderItems + atomic stock decrement, in one
+ * transaction. Stock decrements happen here and only here — never on
+ * cart-add or checkout-start.
+ *
+ * Idempotent on stripeSessionId: a webhook retry for an already-recorded
+ * order returns { created: false } instead of throwing, so the caller can
+ * skip emails without exception flow. Any other error propagates — the
+ * webhook must 500 so Stripe retries, or a paid order is lost forever.
+ */
+export async function recordPaidOrder(
+  prisma: PrismaClient,
+  facts: PaidOrderFacts,
+): Promise<RecordPaidOrderResult> {
+  try {
+    const order = await prisma.$transaction(async (tx) => {
+      const newOrder = await tx.order.create({
+        data: {
+          stripeSessionId: facts.stripeSessionId,
+          status: "paid",
+          total: facts.total,
+          customerEmail: facts.customerEmail,
+          userId: facts.userId,
+          shippingMethod: facts.shippingMethod,
+          shippingAddress: facts.shippingAddress ?? undefined,
+          paymentMethod: facts.paymentMethod,
+        },
+      });
+
+      for (const item of facts.lineItems) {
+        if (item.productId === null) continue; // shipping line — see line-item contract
+
+        await tx.orderItem.create({
+          data: {
+            orderId: newOrder.id,
+            productId: item.productId,
+            quantity: item.quantity,
+            price: item.unitPrice,
+          },
+        });
+
+        await tx.product.update({
+          where: { id: item.productId },
+          data: { stock: { decrement: item.quantity } },
+        });
+      }
+
+      return newOrder;
+    });
+
+    return { created: true, order };
+  } catch (err) {
+    if (isDuplicateSessionError(err)) {
+      return { created: false, reason: "duplicate" };
+    }
+    throw err;
+  }
+}
+
+// P2002 = unique constraint violation; stripeSessionId is the only unique
+// column an insert can collide on, so this is always a webhook retry.
+function isDuplicateSessionError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "P2002"
+  );
+}

--- a/backend/orders/shipping.ts
+++ b/backend/orders/shipping.ts
@@ -1,0 +1,13 @@
+export const SHIPPING_COSTS: Record<string, number> = {
+  paczkomat: 20,
+  inpost_kurier: 25,
+  dpd: 25,
+};
+
+export const FREE_SHIPPING_THRESHOLD = 350;
+
+export const SHIPPING_LABELS: Record<string, string> = {
+  paczkomat: "InPost Paczkomat",
+  inpost_kurier: "InPost Kurier",
+  dpd: "DPD Kurier",
+};

--- a/backend/orders/stripeFacts.test.ts
+++ b/backend/orders/stripeFacts.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type Stripe from "stripe";
+import { paidOrderFactsFromSession } from "./stripeFacts.ts";
+
+function fakeSession(overrides: Record<string, unknown> = {}): Stripe.Checkout.Session {
+  return {
+    id: "cs_test_123",
+    amount_total: 16999, // grosze
+    customer_details: { email: "klient@example.com" },
+    metadata: {
+      userId: "user_abc",
+      shippingMethod: "paczkomat",
+      shippingAddress: JSON.stringify({ firstName: "Jan", city: "Kraków" }),
+    },
+    ...overrides,
+  } as unknown as Stripe.Checkout.Session;
+}
+
+function productLine(productId: number, unitAmount: number, name: string): Stripe.LineItem {
+  return {
+    description: name,
+    quantity: 2,
+    price: {
+      unit_amount: unitAmount,
+      product: { name, metadata: { productId: String(productId) } },
+    },
+  } as unknown as Stripe.LineItem;
+}
+
+const SHIPPING_LINE = {
+  description: "Dostawa — InPost Paczkomat",
+  quantity: 1,
+  price: {
+    unit_amount: 2000,
+    product: { name: "Dostawa — InPost Paczkomat", metadata: {} },
+  },
+} as unknown as Stripe.LineItem;
+
+describe("paidOrderFactsFromSession", () => {
+  it("normalizes session fields into PLN and parses the shipping address", () => {
+    const facts = paidOrderFactsFromSession(fakeSession(), [], "blik");
+
+    expect(facts.stripeSessionId).toBe("cs_test_123");
+    expect(facts.total).toBe(169.99);
+    expect(facts.customerEmail).toBe("klient@example.com");
+    expect(facts.userId).toBe("user_abc");
+    expect(facts.shippingMethod).toBe("paczkomat");
+    expect(facts.shippingAddress).toEqual({ firstName: "Jan", city: "Kraków" });
+    expect(facts.paymentMethod).toBe("blik");
+  });
+
+  it("handles guest sessions with no metadata gracefully", () => {
+    const facts = paidOrderFactsFromSession(
+      fakeSession({ metadata: {}, customer_details: null }),
+      [],
+      null,
+    );
+    expect(facts.customerEmail).toBeNull();
+    expect(facts.userId).toBeNull();
+    expect(facts.shippingMethod).toBeNull();
+    expect(facts.shippingAddress).toBeNull();
+  });
+
+  it("reads productId from metadata for product lines (line-item contract)", () => {
+    const facts = paidOrderFactsFromSession(
+      fakeSession(),
+      [productLine(7, 14999, "Rama Dębowa 30×40")],
+      null,
+    );
+    expect(facts.lineItems).toEqual([
+      { productId: 7, name: "Rama Dębowa 30×40", quantity: 2, unitPrice: 149.99 },
+    ]);
+  });
+
+  it("gives the shipping line productId null so intake skips it", () => {
+    const facts = paidOrderFactsFromSession(fakeSession(), [SHIPPING_LINE], null);
+    expect(facts.lineItems).toEqual([
+      {
+        productId: null,
+        name: "Dostawa — InPost Paczkomat",
+        quantity: 1,
+        unitPrice: 20,
+      },
+    ]);
+  });
+
+  it("falls back to the product name when description is missing", () => {
+    const line = productLine(7, 14999, "Rama Dębowa 30×40");
+    (line as { description: string | null }).description = null;
+    const facts = paidOrderFactsFromSession(fakeSession(), [line], null);
+    expect(facts.lineItems[0].name).toBe("Rama Dębowa 30×40");
+  });
+});

--- a/backend/orders/stripeFacts.ts
+++ b/backend/orders/stripeFacts.ts
@@ -1,0 +1,41 @@
+import type Stripe from "stripe";
+import type { PaidOrderFacts, PaidLineItem } from "./types.ts";
+
+/**
+ * Normalize a completed Stripe checkout session into plain order facts.
+ * This is the read side of the line-item contract: lines stamped with
+ * metadata.productId at checkout become product lines; anything else
+ * (shipping) gets productId null.
+ */
+export function paidOrderFactsFromSession(
+  session: Stripe.Checkout.Session,
+  lineItems: Stripe.LineItem[],
+  paymentMethod: string | null,
+): PaidOrderFacts {
+  return {
+    stripeSessionId: session.id,
+    total: (session.amount_total ?? 0) / 100,
+    customerEmail: session.customer_details?.email ?? null,
+    userId: session.metadata?.userId ?? null,
+    shippingMethod: session.metadata?.shippingMethod || null,
+    shippingAddress: session.metadata?.shippingAddress
+      ? JSON.parse(session.metadata.shippingAddress)
+      : null,
+    paymentMethod,
+    lineItems: lineItems.map(toPaidLineItem),
+  };
+}
+
+function toPaidLineItem(item: Stripe.LineItem): PaidLineItem {
+  // listLineItems is called with expand: ["data.price.product"], so product
+  // is the full object, never a bare id string.
+  const product = item.price?.product as Stripe.Product | undefined;
+  const rawProductId = Number(product?.metadata?.productId);
+
+  return {
+    productId: Number.isInteger(rawProductId) && rawProductId > 0 ? rawProductId : null,
+    name: item.description ?? product?.name ?? "",
+    quantity: item.quantity ?? 1,
+    unitPrice: (item.price?.unit_amount ?? 0) / 100,
+  };
+}

--- a/backend/orders/types.ts
+++ b/backend/orders/types.ts
@@ -1,0 +1,44 @@
+import type { ShippingAddress } from "../emails/types.ts";
+
+/** Cart item as sent by the frontend — untrusted until validated. */
+export interface CartItemInput {
+  id: unknown;
+  quantity: unknown;
+}
+
+/** The slice of Product the checkout builder needs. */
+export interface CheckoutProduct {
+  id: number;
+  name: string;
+  /** Unit price in PLN (not grosze). */
+  price: number;
+  stock: number;
+  imageUrl: string | null;
+}
+
+/**
+ * One line of a paid order, normalized from Stripe.
+ * `productId: null` marks the shipping line item — see "Line-item contract"
+ * in CONTEXT.md: only lines stamped with metadata.productId at checkout
+ * become OrderItems and decrement stock.
+ */
+export interface PaidLineItem {
+  productId: number | null;
+  name: string;
+  quantity: number;
+  /** Unit price in PLN (not grosze). */
+  unitPrice: number;
+}
+
+/** Everything order intake needs, already fetched from Stripe and normalized. */
+export interface PaidOrderFacts {
+  stripeSessionId: string;
+  /** Grand total in PLN, including shipping. */
+  total: number;
+  customerEmail: string | null;
+  userId: string | null;
+  shippingMethod: string | null;
+  shippingAddress: ShippingAddress;
+  paymentMethod: string | null;
+  lineItems: PaidLineItem[];
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,9 @@
     "start": "tsx index.js",
     "build": "prisma generate && prisma migrate deploy",
     "seed": "tsx seed.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:db": "vitest run --config vitest.db.config.ts",
+    "test:db:prepare": "node scripts/prepare-test-db.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/prepare-test-db.js
+++ b/backend/scripts/prepare-test-db.js
@@ -1,0 +1,38 @@
+/**
+ * One-time setup for the DB-backed test suite (`npm run test:db`):
+ * creates the test database if missing and applies migrations to it.
+ */
+import "dotenv/config";
+import { spawnSync } from "node:child_process";
+import pg from "pg";
+import { resolveTestDatabaseUrl } from "./test-db-url.js";
+
+const testUrl = resolveTestDatabaseUrl();
+const url = new URL(testUrl);
+const dbName = url.pathname.slice(1);
+
+// CREATE DATABASE can't run inside the target DB — connect to the
+// server's maintenance database instead.
+const adminUrl = new URL(testUrl);
+adminUrl.pathname = "/postgres";
+
+const client = new pg.Client({ connectionString: adminUrl.toString() });
+await client.connect();
+try {
+  await client.query(`CREATE DATABASE "${dbName}"`);
+  console.log(`Created test database ${dbName}`);
+} catch (err) {
+  if (err.code !== "42P04") throw err; // 42P04 = already exists
+  console.log(`Test database ${dbName} already exists`);
+} finally {
+  await client.end();
+}
+
+// prisma.config.ts reads DATABASE_URL; dotenv won't override a var that's
+// already set, so this env override wins.
+const result = spawnSync("npx", ["prisma", "migrate", "deploy"], {
+  stdio: "inherit",
+  shell: true,
+  env: { ...process.env, DATABASE_URL: testUrl },
+});
+process.exit(result.status ?? 1);

--- a/backend/scripts/test-db-url.js
+++ b/backend/scripts/test-db-url.js
@@ -1,0 +1,33 @@
+/**
+ * Resolve the Postgres URL for the DB-backed test suite.
+ *
+ * Uses TEST_DATABASE_URL when set; otherwise derives one from DATABASE_URL
+ * by appending "_test" to the database name. Either way the resolved
+ * database name MUST end in "_test" — a hard guard so the suite can never
+ * truncate the dev or prod database.
+ */
+export function resolveTestDatabaseUrl() {
+  const explicit = process.env.TEST_DATABASE_URL;
+  const derivedFrom = process.env.DATABASE_URL;
+
+  let urlString;
+  if (explicit) {
+    urlString = explicit;
+  } else if (derivedFrom) {
+    const url = new URL(derivedFrom);
+    url.pathname = `${url.pathname}_test`;
+    urlString = url.toString();
+  } else {
+    throw new Error(
+      "DB tests need TEST_DATABASE_URL (or DATABASE_URL to derive it from).",
+    );
+  }
+
+  if (!new URL(urlString).pathname.endsWith("_test")) {
+    throw new Error(
+      `Refusing to run DB tests: database name must end in "_test" (got ${new URL(urlString).pathname}).`,
+    );
+  }
+
+  return urlString;
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from "vitest/config";
 
 // Without a local config vitest walks up and loads the frontend's vite.config
 // (React plugin and all) — pin the backend suite to its own minimal setup.
+// *.db.test.ts files need Postgres and run separately via `npm run test:db`.
 export default defineConfig({
   test: {
-    include: ["emails/**/*.test.ts"],
+    include: ["emails/**/*.test.ts", "orders/**/*.test.ts"],
+    exclude: ["**/*.db.test.ts", "**/node_modules/**"],
   },
 });

--- a/backend/vitest.db.config.ts
+++ b/backend/vitest.db.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// DB-backed suite: needs a Postgres test database (name must end in "_test";
+// see scripts/test-db-url.js). One-time setup: `npm run test:db:prepare`.
+// Tests truncate tables between cases, so they run single-threaded.
+export default defineConfig({
+  test: {
+    include: ["**/*.db.test.ts"],
+    exclude: ["**/node_modules/**"],
+    fileParallelism: false,
+  },
+});

--- a/docs/adr/0001-order-intake-module.md
+++ b/docs/adr/0001-order-intake-module.md
@@ -1,0 +1,12 @@
+# Order intake is a plain-data module; routes stay the Stripe adapters
+
+The Stripe webhook handler inlined the project's most load-bearing invariants (atomic stock decrement on `paid`, `stripeSessionId` idempotency, "email failure never 500s a recorded order") in one HTTP closure, making them untestable. We extracted them into a TypeScript order-intake module (`backend/orders/`) that takes **already-fetched plain data** — the webhook route keeps all Stripe I/O (signature verification, `listLineItems`, payment-method retrieval) and normalizes it before delegating. One adapter per external service, mirroring how `backend/emails/sendEmail.ts` is the only nodemailer path.
+
+Decisions and why:
+
+- **Route keeps Stripe I/O.** The intake module's only external dependency is Prisma, so its tests need Postgres but zero Stripe stubbing. The alternative (module takes `stripe` + `event`) makes the deep module depend on two external services and forces fake Stripe clients into every test.
+- **Idempotency is a discriminated result, not an exception.** `recordPaidOrder` returns `{ created: true, order }` or `{ created: false, reason: "duplicate" }` (mapped from Prisma P2002 on `stripeSessionId`). Webhook retries are routine, not exceptional; the caller sends order emails only when `created` — which also makes "no duplicate emails on retry" explicit instead of an accident of exception flow.
+- **Checkout and webhook extracted together.** Both sides of the line-item contract (`metadata.productId` stamped at checkout, read back in intake; shipping = the productId-less line item) live in one module so the contract is visible and tested in both directions.
+- **DB-backed integration tests, split scripts.** The transaction + idempotency semantics are exactly what fakes can't prove, so they're tested against a real Postgres via `TEST_DATABASE_URL`. `npm test` stays the fast infra-free unit suite; the DB suite runs separately.
+
+This is the "backend `index.js` split" initiative referenced in CONTEXT.md's out-of-scope list — business-logic extraction, not a routes/ reorganization.


### PR DESCRIPTION
## Summary
- New `backend/orders/` module (TypeScript, mirroring `backend/emails/`): `buildCheckoutLineItems` (server-authoritative pricing/stock validation/free-shipping, stamps `metadata.productId`), `paidOrderFactsFromSession` (the read side of the line-item contract), `recordPaidOrder` (transaction + atomic stock decrement + P2002→`{created:false}` idempotency), `notifyOrderPlaced` (best-effort customer + admin emails, never throws).
- The webhook and `/create-checkout-session` routes in `index.js` are now thin Stripe adapters; shipping constants moved into the module. Retry-sends-no-duplicate-emails is now a typed `result.created` guard instead of an exception-flow accident.
- Design recorded in `docs/adr/0001-order-intake-module.md` (first ADR); CONTEXT.md gained **Order intake** and **Line-item contract** glossary terms.
- Tests: 12 new unit tests (`npm test`, still infra-free) + 3 DB-backed tests (`npm run test:db`) proving atomic decrement, duplicate no-op, and full rollback against a real Postgres. `npm run test:db:prepare` creates/migrates the test DB; its name must end in `_test` (hard guard).

## Test plan
- [x] `npm test` in `backend/` — 5 files, 23 tests passing
- [x] `npm run test:db:prepare` + `npm run test:db` — 3 tests passing against `shop_sznyt_design_test`
- [x] Backend boots via `npx tsx index.js`, `/products` 200
- [x] Stripe CLI e2e (SMTP disabled): `checkout.session.completed` → webhook 200, order recorded `paid`, both demo-mode email lines; `stripe events resend` → 200 no-op, no duplicate emails, no double decrement; fixture line without `metadata.productId` correctly skipped

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)