### PR TITLE
refactor: apiFetch client + useResource hook (#45)

### DIFF
--- a/src/hooks/useResource.ts
+++ b/src/hooks/useResource.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "@clerk/react";
+import { apiFetch } from "../lib/api";
+
+/**
+ * Load a backend resource on mount. Pass `path: null` to hold off
+ * (e.g. until Clerk resolves the user). `auth: true` attaches the
+ * Clerk session token. `data` stays null while loading or on error.
+ */
+export function useResource<T>(
+  path: string | null,
+  opts: { auth?: boolean } = {},
+): { data: T | null; error: boolean } {
+  const { auth = false } = opts;
+  const { getToken } = useAuth();
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (path === null) return;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const result = await apiFetch<T>(path as string, auth ? { auth: getToken } : {});
+        if (!cancelled) setData(result);
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    }
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [path, auth, getToken]);
+
+  return { data, error };
+}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { apiFetch, ApiError } from "./api";
+
+function jsonResponse(status: number, body?: unknown) {
+  return new Response(body === undefined ? null : JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv("VITE_API_URL", "http://api.test");
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  fetchMock.mockReset();
+});
+
+describe("apiFetch", () => {
+  it("prefixes the path with the API base URL and returns parsed JSON", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, [{ id: 1 }]));
+
+    const data = await apiFetch<{ id: number }[]>("/products");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://api.test/products",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(data).toEqual([{ id: 1 }]);
+  });
+
+  it("serializes body as JSON and sets Content-Type", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+    await apiFetch("/contact", { method: "POST", body: { name: "Jan" } });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBe(JSON.stringify({ name: "Jan" }));
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+
+  it("attaches a Bearer token from the auth provider", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+    await apiFetch("/orders", { auth: async () => "tok_123" });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok_123");
+  });
+
+  it("sends no Content-Type or Authorization headers when not asked to", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, {}));
+
+    await apiFetch("/products");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual({});
+  });
+
+  it("throws ApiError carrying the server's error message on non-ok responses", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(400, { error: "Brak produktu" }));
+
+    const err = await apiFetch("/products/999").catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).message).toBe("Brak produktu");
+    expect((err as ApiError).status).toBe(400);
+  });
+
+  it("throws ApiError with an empty message when the error body is not JSON", async () => {
+    fetchMock.mockResolvedValue(new Response("<html>Bad Gateway</html>", { status: 502 }));
+
+    const err = await apiFetch("/products").catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).message).toBe("");
+    expect((err as ApiError).status).toBe(502);
+  });
+
+  it("returns undefined for an empty ok response body", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(apiFetch("/orders/1/fulfillment", { method: "PATCH" })).resolves.toBeUndefined();
+  });
+
+  it("lets network failures propagate untouched", async () => {
+    const boom = new TypeError("Failed to fetch");
+    fetchMock.mockRejectedValue(boom);
+
+    await expect(apiFetch("/products")).rejects.toBe(boom);
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,52 @@
-const API_URL = import.meta.env.VITE_API_URL as string;
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
 
-export default API_URL;
+export type ApiFetchOptions = {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /** JSON-serialized into the request body; sets Content-Type automatically. */
+  body?: unknown;
+  /** Token provider (Clerk's `getToken`); attaches an Authorization header. */
+  auth?: () => Promise<string | null>;
+};
+
+/**
+ * Fetch against the backend API. Throws ApiError on any non-ok response,
+ * with `message` set to the server's `error` field when it provides one.
+ * Network failures propagate as-is (not ApiError).
+ */
+export async function apiFetch<T = unknown>(
+  path: string,
+  opts: ApiFetchOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+  if (opts.auth) headers.Authorization = `Bearer ${await opts.auth()}`;
+
+  const res = await fetch(`${import.meta.env.VITE_API_URL as string}${path}`, {
+    method: opts.method ?? "GET",
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+
+  const text = await res.text();
+
+  if (!res.ok) {
+    let serverError = "";
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed?.error === "string") serverError = parsed.error;
+    } catch {
+      // non-JSON error body (proxy HTML, empty) — no server message to surface
+    }
+    throw new ApiError(serverError, res.status);
+  }
+
+  return text ? (JSON.parse(text) as T) : (undefined as T);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,10 @@
 export class ApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-  ) {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
     super(message);
     this.name = "ApiError";
+    this.status = status;
   }
 }
 

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@clerk/react";
 import type { ShippingMethod, CourierAddress, PaczkomatPoint } from "../types";
 import { SHIPPING_COSTS, FREE_SHIPPING_THRESHOLD, calcShippingCost } from "../lib/shipping";
 import { validateAddress } from "../lib/checkout-validation";
+import { apiFetch } from "../lib/api";
 import Seo from "../components/Seo";
 
 const IS_DEMO_MODE = import.meta.env.VITE_DEMO_MODE === "true";
@@ -87,22 +88,16 @@ function Cart() {
         shippingMethod === "paczkomat"
           ? { ...paczkomatPoint, ...address }
           : address;
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/create-checkout-session`, {
+      const data = await apiFetch<{ url?: string }>("/create-checkout-session", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+        body: {
           // backend prices from the DB — it only needs ids and quantities
           items: items.map(({ id, quantity }) => ({ id, quantity })),
           userId,
           shippingMethod,
           shippingAddress,
-        }),
+        },
       });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || "Błąd serwera");
-      }
-      const data = await res.json();
       if (!data.url) throw new Error("Nie udało się otworzyć strony płatności");
       window.location.href = data.url;
     } catch (err) {

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
+import { apiFetch, ApiError } from "../lib/api";
 
 function Contact() {
   const [name, setName] = useState("");
@@ -16,22 +17,18 @@ function Contact() {
     if (honeypot) { setSuccess(true); return; }
     setLoading(true);
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/contact`, {
+      await apiFetch("/contact", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email, message, _hp: honeypot }),
+        body: { name, email, message, _hp: honeypot },
       });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Coś poszło nie tak. Spróbuj ponownie.");
-        return;
-      }
       setSuccess(true);
       setName("");
       setEmail("");
       setMessage("");
-    } catch {
-      setError("Coś poszło nie tak. Spróbuj ponownie.");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.message ? err.message : "Coś poszło nie tak. Spróbuj ponownie.",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,24 +2,13 @@ import ProductSection from "../components/ProductSection";
 import Hero from "../components/Hero";
 import BrandStatement from "../components/BrandStatement";
 import Seo from "../components/Seo";
-import { useState, useEffect } from "react";
 import type { Product } from "../types";
+import { useResource } from "../hooks/useResource";
 
 function Home() {
-  const [products, setProducts] = useState<Product[]>([]);
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products`);
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setProducts(data);
-      } catch {
-        // products stays empty — page still renders with Hero and BrandStatement
-      }
-    }
-    load();
-  }, []);
+  // on error products stays empty — page still renders with Hero and BrandStatement
+  const { data } = useResource<Product[]>("/products");
+  const products = data ?? [];
 
   return (
     <>

--- a/src/pages/MyOrders.tsx
+++ b/src/pages/MyOrders.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
 import { RedirectToSignIn, useAuth } from "@clerk/react";
+import { useResource } from "../hooks/useResource";
 import type { Order } from "../types";
 import Skeleton from "../components/Skeleton";
 import { Link } from "react-router-dom";
@@ -39,27 +39,12 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 function MyOrders() {
-  const [orders, setOrders] = useState<Order[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const { userId, isLoaded, getToken } = useAuth();
-
-  useEffect(() => {
-    if (!userId) return;
-    async function load() {
-      try {
-        const token = await getToken();
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/orders/user/${userId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setOrders(data);
-      } catch {
-        setError("Nie udało się załadować zamówień. Spróbuj ponownie.");
-      }
-    }
-    load();
-  }, [userId, getToken]);
+  const { userId, isLoaded } = useAuth();
+  const { data: orders, error: loadFailed } = useResource<Order[]>(
+    userId ? `/orders/user/${userId}` : null,
+    { auth: true },
+  );
+  const error = loadFailed ? "Nie udało się załadować zamówień. Spróbuj ponownie." : null;
 
   if (!isLoaded) return null;
   if (!userId) return <RedirectToSignIn />;

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from "react";
 import { useParams, Link, Navigate } from "react-router-dom";
 import { useAuth } from "@clerk/react";
 import type { Order } from "../types";
 import Seo from "../components/Seo";
+import { useResource } from "../hooks/useResource";
 
 const ORDER_DETAIL_DESCRIPTION =
   "Podgląd zamówienia w Sznyt Design — pozycje, adres dostawy, sposób płatności i status realizacji.";
@@ -55,27 +55,12 @@ function FulfillmentBadge({ status }: { status: string }) {
 
 function OrderDetail() {
   const { id } = useParams();
-  const { userId, isLoaded, getToken } = useAuth();
-  const [order, setOrder] = useState<Order | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!userId) return;
-    async function load() {
-      try {
-        const token = await getToken();
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/orders/${id}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setOrder(data);
-      } catch {
-        setError("Nie udało się załadować zamówienia.");
-      }
-    }
-    load();
-  }, [userId, id, getToken]);
+  const { userId, isLoaded } = useAuth();
+  const { data: order, error: loadFailed } = useResource<Order>(
+    userId ? `/orders/${id}` : null,
+    { auth: true },
+  );
+  const error = loadFailed ? "Nie udało się załadować zamówienia." : null;
 
   if (!isLoaded) return null;
   if (!userId) return <Navigate to="/moje-zamowienia" />;

--- a/src/pages/OrderSuccess.tsx
+++ b/src/pages/OrderSuccess.tsx
@@ -5,6 +5,7 @@ import type { Order } from "../types";
 import { Show } from "@clerk/react";
 import { useCart } from "../hooks/useCart";
 import Seo from "../components/Seo";
+import { apiFetch } from "../lib/api";
 
 function OrderSuccess() {
   const [searchParams] = useSearchParams();
@@ -22,18 +23,13 @@ function OrderSuccess() {
       // poll briefly before assuming anything is wrong.
       for (let attempt = 1; attempt <= 5; attempt++) {
         try {
-          const res = await fetch(
-            `${import.meta.env.VITE_API_URL as string}/orders/by-session/${sessionId}`,
-          );
-          if (res.ok) {
-            const data = await res.json();
-            if (cancelled) return;
-            setOrder(data);
-            clearCart();
-            return;
-          }
+          const data = await apiFetch<Order>(`/orders/by-session/${sessionId}`);
+          if (cancelled) return;
+          setOrder(data);
+          clearCart();
+          return;
         } catch {
-          // network hiccup — fall through to retry
+          // order not recorded yet or network hiccup — fall through to retry
         }
         await new Promise((resolve) => setTimeout(resolve, attempt * 1500));
       }

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -1,14 +1,15 @@
 import { useParams, Link } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useCart } from "../hooks/useCart";
 import type { Product } from "../types";
 import Skeleton from "../components/Skeleton";
 import Seo from "../components/Seo";
+import { useResource } from "../hooks/useResource";
 
 function ProductDetails() {
   const { id } = useParams();
-  const [product, setProduct] = useState<Product | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { data: product, error: loadFailed } = useResource<Product>(`/products/${id}`);
+  const error = loadFailed ? "Nie udało się załadować produktu." : null;
   const [hovered, setHovered] = useState(false);
   const [added, setAdded] = useState(false);
   const { addItem, items } = useCart();
@@ -22,20 +23,6 @@ function ProductDetails() {
       setAdded(false);
     }, 3000);
   }
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products/${id}`);
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setProduct(data);
-      } catch {
-        setError("Nie udało się załadować produktu.");
-      }
-    }
-    load();
-  }, [id]);
 
   if (error)
     return (

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { Product } from "../types";
 import Seo from "../components/Seo";
+import { useResource } from "../hooks/useResource";
 
 function ProductCard({ product }: { product: Product }) {
   const [hovered, setHovered] = useState(false);
@@ -40,22 +41,9 @@ function ProductCard({ product }: { product: Product }) {
 }
 
 function Shop() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products`);
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setProducts(data);
-      } catch {
-        setError("Nie udało się załadować produktów. Spróbuj ponownie.");
-      }
-    }
-    load();
-  }, []);
+  const { data, error: loadFailed } = useResource<Product[]>("/products");
+  const products = data ?? [];
+  const error = loadFailed ? "Nie udało się załadować produktów. Spróbuj ponownie." : null;
 
   return (
     <main>

--- a/src/pages/Zwroty.tsx
+++ b/src/pages/Zwroty.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
+import { apiFetch, ApiError } from "../lib/api";
 
 function ZwrotForm() {
   const [orderNumber, setOrderNumber] = useState("");
@@ -19,16 +20,17 @@ function ZwrotForm() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/zwrot`, {
+      await apiFetch("/zwrot", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderNumber, name, email, reason, bankAccount, _hp: honeypot }),
+        body: { orderNumber, name, email, reason, bankAccount, _hp: honeypot },
       });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error); return; }
       setSuccess(true);
-    } catch {
-      setError("Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.message
+          ? err.message
+          : "Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.",
+      );
     } finally {
       setLoading(false);
     }
@@ -104,16 +106,17 @@ function ReklamacjaForm() {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/reklamacja`, {
+      await apiFetch("/reklamacja", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderNumber, name, email, description, _hp: honeypot }),
+        body: { orderNumber, name, email, description, _hp: honeypot },
       });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error); return; }
       setSuccess(true);
-    } catch {
-      setError("Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.message
+          ? err.message
+          : "Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/AdminAddProduct.tsx
+++ b/src/pages/admin/AdminAddProduct.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@clerk/react";
+import { apiFetch, ApiError } from "../../lib/api";
 
 function AdminAddProduct() {
   const { getToken } = useAuth();
@@ -23,21 +24,15 @@ function AdminAddProduct() {
     setError("");
     setLoading(true);
     try {
-      const token = await getToken();
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products`, {
+      await apiFetch("/products", {
         method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
+        auth: getToken,
+        body: {
           ...formData,
           price: Number(formData.price),
           stock: Number(formData.stock),
-        }),
+        },
       });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Coś poszło nie tak");
-        return;
-      }
       setFormData({
         name: "",
         tagline: "",
@@ -48,8 +43,10 @@ function AdminAddProduct() {
         stock: "",
       });
       navigate("/admin");
-    } catch {
-      setError("Coś poszło nie tak, spróbuj ponownie");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.message ? err.message : "Coś poszło nie tak, spróbuj ponownie",
+      );
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/AdminEditProduct.tsx
+++ b/src/pages/admin/AdminEditProduct.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useAuth } from "@clerk/react";
+import type { Product } from "../../types";
+import { apiFetch, ApiError } from "../../lib/api";
+import { useResource } from "../../hooks/useResource";
 
 function AdminEditProduct() {
   const { getToken } = useAuth();
@@ -19,39 +22,37 @@ function AdminEditProduct() {
   const { id } = useParams();
   const navigate = useNavigate();
 
+  const { data: product, error: loadFailed } = useResource<Product>(`/products/${id}`);
+
   useEffect(() => {
-    async function load() {
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products/${id}`);
-      const data = await res.json();
-      setFormData({
-        ...data,
-        price: String(data.price),
-        stock: String(data.stock),
-      });
-    }
-    load();
-  }, [id]);
+    if (!product) return;
+    setFormData({
+      name: product.name,
+      tagline: product.tagline,
+      description: product.description,
+      price: String(product.price),
+      imageUrl: product.imageUrl,
+      lifestyleImageUrl: product.lifestyleImageUrl,
+      stock: String(product.stock),
+    });
+  }, [product]);
+
+  const displayError = error || (loadFailed ? "Nie udało się załadować produktu." : "");
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
     setError("");
     setLoading(true);
     try {
-      const token = await getToken();
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products/${id}`, {
+      await apiFetch(`/products/${id}`, {
         method: "PUT",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({
+        auth: getToken,
+        body: {
           ...formData,
           price: Number(formData.price),
           stock: Number(formData.stock),
-        }),
+        },
       });
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || "Coś poszło nie tak");
-        return;
-      }
       setFormData({
         name: "",
         tagline: "",
@@ -62,8 +63,10 @@ function AdminEditProduct() {
         stock: "",
       });
       navigate("/admin");
-    } catch {
-      setError("Coś poszło nie tak, spróbuj ponownie");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.message ? err.message : "Coś poszło nie tak, spróbuj ponownie",
+      );
     } finally {
       setLoading(false);
     }
@@ -73,7 +76,7 @@ function AdminEditProduct() {
     <>
       <div className="max-w-2xl mx-auto py-10 px-6">
         <h1 className="text-center p-6 text-2xl">Edytuj produkt</h1>
-        {error && <p className="text-red-600 font-dm-sans mb-4">{error}</p>}
+        {displayError && <p className="text-red-600 font-dm-sans mb-4">{displayError}</p>}
         <form onSubmit={handleSubmit}>
           <div className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-4 sm:items-center">
             <label>Nazwa</label>

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { AdminOrder } from "../../types";
 import { useAuth } from "@clerk/react";
 import Skeleton from "../../components/Skeleton";
+import { apiFetch } from "../../lib/api";
+import { useResource } from "../../hooks/useResource";
 
 const FULFILLMENT_LABELS: Record<string, string> = {
   received: "Przyjęte",
@@ -12,7 +14,8 @@ const FULFILLMENT_LABELS: Record<string, string> = {
 
 const FULFILLMENT_OPTIONS = ["received", "processing", "shipped", "delivered"];
 
-function FulfillmentCell({ order, token }: { order: AdminOrder; token: string }) {
+function FulfillmentCell({ order }: { order: AdminOrder }) {
+  const { getToken } = useAuth();
   const [status, setStatus] = useState(order.fulfillmentStatus);
   const [tracking, setTracking] = useState(order.trackingNumber ?? "");
   const [saving, setSaving] = useState(false);
@@ -20,10 +23,10 @@ function FulfillmentCell({ order, token }: { order: AdminOrder; token: string })
   async function save(newStatus: string, newTracking: string) {
     setSaving(true);
     try {
-      await fetch(`${import.meta.env.VITE_API_URL as string}/orders/${order.id}/fulfillment`, {
+      await apiFetch(`/orders/${order.id}/fulfillment`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ fulfillmentStatus: newStatus, trackingNumber: newTracking }),
+        auth: getToken,
+        body: { fulfillmentStatus: newStatus, trackingNumber: newTracking },
       });
     } catch {
       // non-blocking
@@ -60,28 +63,8 @@ function FulfillmentCell({ order, token }: { order: AdminOrder; token: string })
 }
 
 function AdminOrders() {
-  const { getToken } = useAuth();
-  const [orders, setOrders] = useState<AdminOrder[] | null>(null);
-  const [token, setToken] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const t = await getToken();
-        setToken(t);
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/orders`, {
-          headers: { Authorization: `Bearer ${t}` },
-        });
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setOrders(data);
-      } catch {
-        setError("Nie udało się załadować zamówień.");
-      }
-    }
-    load();
-  }, [getToken]);
+  const { data: orders, error: loadFailed } = useResource<AdminOrder[]>("/orders", { auth: true });
+  const error = loadFailed ? "Nie udało się załadować zamówień." : null;
 
   if (error) return <p className="p-4 text-red-600 font-dm-sans text-sm">{error}</p>;
 
@@ -131,7 +114,7 @@ function AdminOrders() {
               <td className="p-3 text-xs">{order.customerEmail ?? "—"}</td>
               <td className="p-3">{order.status}</td>
               <td className="p-3">
-                <FulfillmentCell order={order} token={token!} />
+                <FulfillmentCell order={order} />
               </td>
               <td className="p-3">{order.total} PLN</td>
               <td className="p-3">{order.shippingMethod ?? "—"}</td>

--- a/src/pages/admin/AdminProducts.tsx
+++ b/src/pages/admin/AdminProducts.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "@clerk/react";
 import Skeleton from "../../components/Skeleton";
+import { apiFetch } from "../../lib/api";
+import { useResource } from "../../hooks/useResource";
 
 type Products = {
   id: number;
@@ -17,36 +19,22 @@ type Products = {
 
 function AdminProducts() {
   const { getToken } = useAuth();
-  const [products, setProducts] = useState<Products[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { data: loaded, error: loadFailed } = useResource<Products[]>("/products");
+  // delete/reorder mutate the list locally; until then the loaded resource is the list
+  const [override, setOverride] = useState<Products[] | null>(null);
+  const products = override ?? loaded;
+  const [actionError, setActionError] = useState<string | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [productToDelete, setProductToDelete] = useState<number | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products`);
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setProducts(data);
-      } catch {
-        setError("Nie udało się załadować produktów.");
-      }
-    }
-    load();
-  }, []);
+  const error = actionError ?? (loadFailed ? "Nie udało się załadować produktów." : null);
 
   async function handleDelete(id: number) {
     try {
-      const token = await getToken();
-      const res = await fetch(`${import.meta.env.VITE_API_URL as string}/products/${id}`, {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error();
-      setProducts(products!.filter((p) => p.id !== id));
+      await apiFetch(`/products/${id}`, { method: "DELETE", auth: getToken });
+      setOverride(products!.filter((p) => p.id !== id));
     } catch {
-      setError("Nie udało się usunąć produktu.");
+      setActionError("Nie udało się usunąć produktu.");
     }
   }
 
@@ -63,20 +51,19 @@ function AdminProducts() {
 
     // swap positions in array too
     [updated[index], updated[swapIndex]] = [updated[swapIndex], updated[index]];
-    setProducts(updated);
+    setOverride(updated);
 
     try {
-      const token = await getToken();
-      await fetch(`${import.meta.env.VITE_API_URL as string}/products/reorder`, {
+      await apiFetch("/products/reorder", {
         method: "PATCH",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify([
+        auth: getToken,
+        body: [
           { id: updated[index].id, sortOrder: updated[index].sortOrder },
           { id: updated[swapIndex].id, sortOrder: updated[swapIndex].sortOrder },
-        ]),
+        ],
       });
     } catch {
-      setError("Nie udało się zapisać kolejności.");
+      setActionError("Nie udało się zapisać kolejności.");
     }
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -5,4 +6,9 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  test: {
+    // *.db.test.* needs Postgres and runs via backend's `npm run test:db`;
+    // the root suite stays infra-free
+    exclude: ['**/*.db.test.*', '**/node_modules/**'],
+  },
 })


### PR DESCRIPTION
## Summary
- New deep module `src/lib/api.ts`: `apiFetch(path, opts)` owns the base URL, JSON headers, Clerk token attachment (opt-in `auth: getToken`), and normalized `ApiError` throwing; 8 unit tests cover headers, error shape, empty bodies, and network passthrough.
- New `src/hooks/useResource.ts` collapses the hand-rolled `useState/useEffect/getToken/fetch/setError` load-state machines; `path: null` defers loading until Clerk resolves.
- All 19 fetch call sites across 13 pages migrated; none stay raw. Net −105 lines in pages.
- `AdminOrders` no longer threads a raw token into `FulfillmentCell`; `AdminEditProduct`'s load gains error handling it lacked; `Zwroty` can no longer call `setError(undefined)`.
- Root `npm test` no longer sweeps up the Postgres-backed `*.db.test.*` files (pre-existing failure; they run via backend's `npm run test:db`).

## Design decisions (per ticket)
- **Error shape:** `ApiError { status, message }` — message is the server's `error` field when present, else empty; callers keep the `err.message || polishFallback` pattern.
- **Refetch:** not in `useResource` — no current call site refetches (YAGNI).
- **Raw call sites:** none; `OrderSuccess` keeps its polling loop but calls `apiFetch` inside it.

## Test plan
- [x] `npm run lint`, `tsc -b`, `npm run build`, `npm test` (41 passed)
- [x] Verified in the running app: Shop/Home/ProductDetail render via `useResource`; bad product id shows the Polish error; full cart → checkout POST lands on Stripe Checkout with correct totals; signed-out `/moje-zamowienia` redirects to Clerk with no backend request fired

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)