### PR TITLE
fix: exit non-zero when backend port is already in use

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -450,10 +450,23 @@ app.post("/reklamacja", formLimiter, async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
+// Express 5 passes listen errors to this callback (and registers it as the
+// server's `error` handler), so without the guard the banner prints and the
+// process exits 0 even when the port is taken.
+const server = app.listen(PORT, (err) => {
+  if (err) return; // handled by the `error` listener below
   if (isDemoMode) {
     console.log(`[DEMO MODE] Backend on :${PORT} — Stripe: ${stripe ? "on" : "off"}, SMTP: ${process.env.SMTP_HOST ? "on" : "off"}`);
   } else {
     console.log(`Server running on http://localhost:${PORT}`);
   }
+});
+
+server.on("error", (err) => {
+  if (err.code === "EADDRINUSE") {
+    console.error(`Port ${PORT} is already in use — is a stale backend instance still running? Stop it and retry.`);
+  } else {
+    console.error("Server failed to start:", err);
+  }
+  process.exit(1);
 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -462,7 +462,7 @@ const server = app.listen(PORT, (err) => {
   }
 });
 
-server.on("error", (err) => {
+server.on("error", function handleServerStartupError(err) {
   if (err.code === "EADDRINUSE") {
     console.error(`Port ${PORT} is already in use — is a stale backend instance still running? Stop it and retry.`);
   } else {


### PR DESCRIPTION
## Summary
- Root cause: Express 5's `app.listen` registers the listen callback as the server's `error` handler and invokes it with the error as first argument (`express/lib/application.js:598-606`). Our callback ignored its args, so on `EADDRINUSE` it printed the startup banner, suppressed the crash, and exited 0 — leaving a stale instance silently serving.
- Fix: guard the listen callback (`if (err) return`) so the false banner never prints, and attach an explicit named `error` handler that logs a clear message on `EADDRINUSE` (generic message for any other listen error) and exits 1.

## Test plan
- [x] Reproduced original bug on main: port 3000 held → banner printed, exit code 0
- [x] With fix, port 3000 held → "Port 3000 is already in use — is a stale backend instance still running? Stop it and retry.", exit code 1
- [x] With fix, port free → normal boot, banner prints, server serves
- [x] Backend test suite: 23/23 passing

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)