### PR TITLE
feat: customer order note at checkout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,7 @@ Premium e-commerce shop selling designer wooden picture frames at `sznytdesign.p
 Defined in `backend/prisma/schema.prisma`.
 
 - **Product** — a frame SKU. Has `name`, `tagline`, `description`, `price`, `imageUrl`, `lifestyleImageUrl`, `stock`, `sortOrder`. Stock decrements atomically when an order is paid.
-- **Order** — a customer purchase. Lifecycle: `pending` → `paid` (Stripe webhook); fulfillment: `received` → `shipped`. Carries `stripeSessionId` (unique idempotency key), `customerEmail`, `userId` (nullable — guest checkout allowed), `shippingMethod`, `shippingAddress` (JSON), `paymentMethod`, `fulfillmentStatus`, `trackingNumber`.
+- **Order** — a customer purchase. Lifecycle: `pending` → `paid` (Stripe webhook); fulfillment: `received` → `shipped`. Carries `stripeSessionId` (unique idempotency key), `customerEmail`, `userId` (nullable — guest checkout allowed), `shippingMethod`, `shippingAddress` (JSON), `paymentMethod`, `fulfillmentStatus`, `trackingNumber`, `note` (nullable customer delivery instructions, max 300 chars — travels as its own Stripe `metadata.note` key; cap shared as `ORDER_NOTE_MAX_LENGTH` in `@sznyt/shared`).
 - **OrderItem** — line item linking an `Order` to a `Product` with `quantity` and `price` snapshotted at purchase time. `productId` is nullable with `onDelete: SetNull` — orders survive product deletion with their historical line items intact.
 - **ContactMessage** — submission from the contact form. Stored for support history.
 

--- a/backend/emails/orderSummary.ts
+++ b/backend/emails/orderSummary.ts
@@ -63,7 +63,16 @@ export function orderItemsText(data: OrderEmailData): string {
   return [...rows, "", `Suma: ${formatPln(data.total)}`].join("\n");
 }
 
-export function orderDetailsHtml(data: OrderEmailData): string {
+// The admin alert surfaces the note at the top instead (it must not be
+// missed during fulfillment), so it can opt out of the trailing section.
+export interface OrderDetailsOptions {
+  includeNote?: boolean;
+}
+
+export function orderDetailsHtml(
+  data: OrderEmailData,
+  { includeNote = true }: OrderDetailsOptions = {},
+): string {
   const addressLines = shippingAddressLines(data.shippingAddress, data.shippingMethod);
   const parts = [
     sectionHeadingHtml("Zamówione produkty"),
@@ -78,7 +87,7 @@ export function orderDetailsHtml(data: OrderEmailData): string {
     sectionHeadingHtml("Płatność"),
     `<p style="margin:0;">${escapeHtml(paymentMethodLabel(data.paymentMethod))}</p>`,
   );
-  if (data.note) {
+  if (includeNote && data.note) {
     parts.push(
       sectionHeadingHtml("Uwagi do zamówienia"),
       `<p style="margin:0;">${escapeHtml(data.note)}</p>`,
@@ -87,7 +96,10 @@ export function orderDetailsHtml(data: OrderEmailData): string {
   return parts.join("\n");
 }
 
-export function orderDetailsText(data: OrderEmailData): string {
+export function orderDetailsText(
+  data: OrderEmailData,
+  { includeNote = true }: OrderDetailsOptions = {},
+): string {
   const addressLines = shippingAddressLines(data.shippingAddress, data.shippingMethod);
   const sections = [
     "Zamówione produkty:",
@@ -99,7 +111,7 @@ export function orderDetailsText(data: OrderEmailData): string {
     sections.push("Adres dostawy:", addressLines.join("\n"));
   }
   sections.push(`Metoda płatności: ${paymentMethodLabel(data.paymentMethod)}`);
-  if (data.note) {
+  if (includeNote && data.note) {
     sections.push("Uwagi do zamówienia:", data.note);
   }
   return sections.join("\n");

--- a/backend/emails/orderSummary.ts
+++ b/backend/emails/orderSummary.ts
@@ -78,6 +78,12 @@ export function orderDetailsHtml(data: OrderEmailData): string {
     sectionHeadingHtml("Płatność"),
     `<p style="margin:0;">${escapeHtml(paymentMethodLabel(data.paymentMethod))}</p>`,
   );
+  if (data.note) {
+    parts.push(
+      sectionHeadingHtml("Uwagi do zamówienia"),
+      `<p style="margin:0;">${escapeHtml(data.note)}</p>`,
+    );
+  }
   return parts.join("\n");
 }
 
@@ -93,5 +99,8 @@ export function orderDetailsText(data: OrderEmailData): string {
     sections.push("Adres dostawy:", addressLines.join("\n"));
   }
   sections.push(`Metoda płatności: ${paymentMethodLabel(data.paymentMethod)}`);
+  if (data.note) {
+    sections.push("Uwagi do zamówienia:", data.note);
+  }
   return sections.join("\n");
 }

--- a/backend/emails/renderAdminNewOrder.test.ts
+++ b/backend/emails/renderAdminNewOrder.test.ts
@@ -21,6 +21,7 @@ const sampleOrder: OrderEmailData = {
   },
   paymentMethod: "card",
   customerEmail: "anna@example.com",
+  note: null,
 };
 
 describe("renderAdminNewOrder", () => {
@@ -43,5 +44,20 @@ describe("renderAdminNewOrder", () => {
     expect(output).toContain("30-002 Kraków");
     expect(output).toContain("DPD Kurier");
     expect(output).toContain("Karta płatnicza");
+  });
+
+  it.each(["html", "text"] as const)("shows the customer note in %s", (channel) => {
+    const rendered = renderAdminNewOrder({
+      ...sampleOrder,
+      note: "Kod do bramy: 1234",
+    });
+    const output = channel === "html" ? rendered.html : rendered.text;
+    expect(output).toContain("Uwagi do zamówienia");
+    expect(output).toContain("Kod do bramy: 1234");
+  });
+
+  it("omits the note section when the order has none", () => {
+    expect(html).not.toContain("Uwagi do zamówienia");
+    expect(text).not.toContain("Uwagi do zamówienia");
   });
 });

--- a/backend/emails/renderAdminNewOrder.test.ts
+++ b/backend/emails/renderAdminNewOrder.test.ts
@@ -52,9 +52,22 @@ describe("renderAdminNewOrder", () => {
       note: "Kod do bramy: 1234",
     });
     const output = channel === "html" ? rendered.html : rendered.text;
-    expect(output).toContain("Uwagi do zamówienia");
     expect(output).toContain("Kod do bramy: 1234");
   });
+
+  it.each(["html", "text"] as const)(
+    "shows the note prominently in %s — before the order details",
+    (channel) => {
+      const rendered = renderAdminNewOrder({
+        ...sampleOrder,
+        note: "Kod do bramy: 1234",
+      });
+      const output = channel === "html" ? rendered.html : rendered.text;
+      expect(output.indexOf("Kod do bramy: 1234")).toBeLessThan(
+        output.indexOf("Ramka Orzechowa 21×30"),
+      );
+    },
+  );
 
   it("omits the note section when the order has none", () => {
     expect(html).not.toContain("Uwagi do zamówienia");

--- a/backend/emails/renderAdminNewOrder.ts
+++ b/backend/emails/renderAdminNewOrder.ts
@@ -6,11 +6,14 @@ import type { OrderEmailData, RenderedEmail } from "./types.ts";
 export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
   const subject = `Nowe zamówienie #${data.orderId} — ${formatPln(data.total)}`;
 
+  // Note sits above the order details — a gate code or delivery window
+  // must be seen before the order is packed, not discovered below the fold.
   const html = wrapHtml({
     title: `Nowe zamówienie #${data.orderId}`,
     bodyHtml: `
       ${metaRowHtml("Klient", data.customerEmail ?? "—")}
-      ${orderDetailsHtml(data)}
+      ${data.note ? metaRowHtml("Uwagi klienta", data.note) : ""}
+      ${orderDetailsHtml(data, { includeNote: false })}
       <p style="margin:24px 0 0;">Zamówienie czeka na realizację w panelu administracyjnym.</p>
     `,
   });
@@ -20,8 +23,9 @@ export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
     "",
     `Numer zamówienia: #${data.orderId}`,
     `Klient: ${data.customerEmail ?? "—"}`,
+    ...(data.note ? [`Uwagi klienta: ${data.note}`] : []),
     "",
-    orderDetailsText(data),
+    orderDetailsText(data, { includeNote: false }),
     "",
     "Zamówienie czeka na realizację w panelu administracyjnym.",
   ].join("\n");

--- a/backend/emails/renderOrderConfirmation.test.ts
+++ b/backend/emails/renderOrderConfirmation.test.ts
@@ -23,6 +23,7 @@ const sampleOrder: OrderEmailData = {
   },
   paymentMethod: "blik",
   customerEmail: "jan@example.com",
+  note: null,
 };
 
 describe("renderOrderConfirmation", () => {
@@ -44,6 +45,30 @@ describe("renderOrderConfirmation", () => {
     expect(output).toContain("00-001 Warszawa");
     expect(output).toContain("InPost Paczkomat");
     expect(output).toContain("BLIK");
+  });
+
+  it.each(["html", "text"] as const)("echoes the customer note in %s", (channel) => {
+    const rendered = renderOrderConfirmation({
+      ...sampleOrder,
+      note: "Proszę zostawić u sąsiada",
+    });
+    const output = channel === "html" ? rendered.html : rendered.text;
+    expect(output).toContain("Uwagi do zamówienia");
+    expect(output).toContain("Proszę zostawić u sąsiada");
+  });
+
+  it("omits the note section when the order has none", () => {
+    expect(html).not.toContain("Uwagi do zamówienia");
+    expect(text).not.toContain("Uwagi do zamówienia");
+  });
+
+  it("escapes HTML in the customer note", () => {
+    const { html: noteHtml } = renderOrderConfirmation({
+      ...sampleOrder,
+      note: `<script>alert("x")</script>`,
+    });
+    expect(noteHtml).not.toContain("<script>");
+    expect(noteHtml).toContain("&lt;script&gt;");
   });
 
   it("escapes HTML in user-controlled fields", () => {

--- a/backend/emails/types.ts
+++ b/backend/emails/types.ts
@@ -29,4 +29,6 @@ export interface OrderEmailData {
   shippingAddress: ShippingAddress;
   paymentMethod: string | null;
   customerEmail: string | null;
+  /** Customer delivery instructions from checkout. */
+  note: string | null;
 }

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ import {
 import {
   buildCheckoutLineItems,
   paidOrderFactsFromSession,
+  normalizeOrderNote,
   recordPaidOrder,
   notifyOrderPlaced,
 } from "./orders/index.ts";
@@ -266,7 +267,12 @@ app.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
     if (!stripe) {
       return res.status(503).json({ error: "Checkout disabled in demo mode" });
     }
-    const { items, userId, shippingMethod, shippingAddress } = req.body;
+    const { items, userId, shippingMethod, shippingAddress, note } = req.body;
+
+    const noteResult = normalizeOrderNote(note);
+    if (!noteResult.ok) {
+      return res.status(noteResult.status).json({ error: noteResult.error });
+    }
 
     // Fetch the referenced products; all validation and pricing lives in the
     // order-intake module (server-authoritative — the client only chooses
@@ -294,6 +300,7 @@ app.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
       cancel_url: `${process.env.FRONTEND_URL}/koszyk`,
       metadata: {
         ...(userId ? { userId } : {}),
+        ...(noteResult.note ? { note: noteResult.note } : {}),
         shippingMethod,
         shippingAddress: JSON.stringify(shippingAddress),
       },

--- a/backend/orders/index.ts
+++ b/backend/orders/index.ts
@@ -1,5 +1,6 @@
 export { buildCheckoutLineItems } from "./buildCheckoutLineItems.ts";
 export { paidOrderFactsFromSession } from "./stripeFacts.ts";
+export { normalizeOrderNote } from "./orderNote.ts";
 export { recordPaidOrder } from "./recordPaidOrder.ts";
 export { notifyOrderPlaced } from "./notifyOrderPlaced.ts";
 export type { PaidOrderFacts, PaidLineItem, CheckoutProduct, CartItemInput } from "./types.ts";

--- a/backend/orders/notifyOrderPlaced.ts
+++ b/backend/orders/notifyOrderPlaced.ts
@@ -26,6 +26,7 @@ export async function notifyOrderPlaced(
     shippingAddress: facts.shippingAddress,
     paymentMethod: facts.paymentMethod,
     customerEmail: facts.customerEmail,
+    note: facts.note,
   };
 
   if (emailData.customerEmail) {

--- a/backend/orders/orderNote.test.ts
+++ b/backend/orders/orderNote.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { ORDER_NOTE_MAX_LENGTH } from "@sznyt/shared";
+import { normalizeOrderNote } from "./orderNote.ts";
+
+describe("normalizeOrderNote", () => {
+  it("trims a valid note", () => {
+    expect(normalizeOrderNote("  Proszę zostawić u sąsiada  ")).toEqual({
+      ok: true,
+      note: "Proszę zostawić u sąsiada",
+    });
+  });
+
+  it("normalizes an absent note to null", () => {
+    expect(normalizeOrderNote(undefined)).toEqual({ ok: true, note: null });
+    expect(normalizeOrderNote(null)).toEqual({ ok: true, note: null });
+  });
+
+  it("normalizes a whitespace-only note to null", () => {
+    expect(normalizeOrderNote("   ")).toEqual({ ok: true, note: null });
+  });
+
+  it("accepts a note exactly at the max length", () => {
+    const note = "a".repeat(ORDER_NOTE_MAX_LENGTH);
+    expect(normalizeOrderNote(note)).toEqual({ ok: true, note });
+  });
+
+  it("rejects a note over the max length", () => {
+    const result = normalizeOrderNote("a".repeat(ORDER_NOTE_MAX_LENGTH + 1));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toContain(String(ORDER_NOTE_MAX_LENGTH));
+    }
+  });
+
+  it("rejects a non-string note", () => {
+    const result = normalizeOrderNote(42);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/backend/orders/orderNote.ts
+++ b/backend/orders/orderNote.ts
@@ -1,0 +1,32 @@
+import { ORDER_NOTE_MAX_LENGTH } from "@sznyt/shared";
+
+export type NormalizeOrderNoteResult =
+  | { ok: true; note: string | null }
+  | { ok: false; status: 400; error: string };
+
+/**
+ * Validate the optional customer note from the checkout request body.
+ * Absent or blank collapses to null; the length cap is enforced here because
+ * the client-side maxLength is bypassable and Stripe metadata would reject
+ * oversized values at session creation with an opaque error.
+ */
+export function normalizeOrderNote(raw: unknown): NormalizeOrderNoteResult {
+  if (raw === undefined || raw === null) return { ok: true, note: null };
+
+  if (typeof raw !== "string") {
+    return { ok: false, status: 400, error: "Nieprawidłowe uwagi do zamówienia" };
+  }
+
+  const note = raw.trim();
+  if (note === "") return { ok: true, note: null };
+
+  if (note.length > ORDER_NOTE_MAX_LENGTH) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Uwagi do zamówienia mogą mieć maksymalnie ${ORDER_NOTE_MAX_LENGTH} znaków`,
+    };
+  }
+
+  return { ok: true, note };
+}

--- a/backend/orders/recordPaidOrder.db.test.ts
+++ b/backend/orders/recordPaidOrder.db.test.ts
@@ -47,6 +47,7 @@ function facts(overrides: Partial<PaidOrderFacts> = {}): PaidOrderFacts {
     shippingMethod: "paczkomat",
     shippingAddress: { firstName: "Jan", city: "Kraków" },
     paymentMethod: "blik",
+    note: null,
     lineItems: [
       { productId: 1, name: "Rama Dębowa 30×40", quantity: 2, unitPrice: 149.99 },
       { productId: 2, name: "Rama Jesionowa 21×30", quantity: 1, unitPrice: 89 },
@@ -76,6 +77,27 @@ describe("recordPaidOrder", () => {
     const products = await prisma.product.findMany({ orderBy: { id: "asc" } });
     expect(products[0].stock).toBe(3); // 5 - 2
     expect(products[1].stock).toBe(1); // 2 - 1
+  });
+
+  it("persists the customer note on the order", async () => {
+    await seedProducts();
+
+    const result = await recordPaidOrder(
+      prisma,
+      facts({ note: "Proszę zostawić u sąsiada" }),
+    );
+    expect(result.created).toBe(true);
+    if (!result.created) return;
+    expect(result.order.note).toBe("Proszę zostawić u sąsiada");
+  });
+
+  it("stores null when the order has no note", async () => {
+    await seedProducts();
+
+    const result = await recordPaidOrder(prisma, facts());
+    expect(result.created).toBe(true);
+    if (!result.created) return;
+    expect(result.order.note).toBeNull();
   });
 
   it("treats a duplicate stripeSessionId as a no-op: no second order, no double decrement", async () => {

--- a/backend/orders/recordPaidOrder.ts
+++ b/backend/orders/recordPaidOrder.ts
@@ -31,6 +31,7 @@ export async function recordPaidOrder(
           shippingMethod: facts.shippingMethod,
           shippingAddress: facts.shippingAddress ?? undefined,
           paymentMethod: facts.paymentMethod,
+          note: facts.note,
         },
       });
 

--- a/backend/orders/stripeFacts.test.ts
+++ b/backend/orders/stripeFacts.test.ts
@@ -61,6 +61,22 @@ describe("paidOrderFactsFromSession", () => {
     expect(facts.shippingAddress).toBeNull();
   });
 
+  it("passes the customer note through from session metadata", () => {
+    const facts = paidOrderFactsFromSession(
+      fakeSession({
+        metadata: { shippingMethod: "paczkomat", note: "Proszę zostawić u sąsiada" },
+      }),
+      [],
+      null,
+    );
+    expect(facts.note).toBe("Proszę zostawić u sąsiada");
+  });
+
+  it("gives note null when the session has none", () => {
+    const facts = paidOrderFactsFromSession(fakeSession(), [], null);
+    expect(facts.note).toBeNull();
+  });
+
   it("reads productId from metadata for product lines (line-item contract)", () => {
     const facts = paidOrderFactsFromSession(
       fakeSession(),

--- a/backend/orders/stripeFacts.ts
+++ b/backend/orders/stripeFacts.ts
@@ -22,6 +22,7 @@ export function paidOrderFactsFromSession(
       ? JSON.parse(session.metadata.shippingAddress)
       : null,
     paymentMethod,
+    note: session.metadata?.note || null,
     lineItems: lineItems.map(toPaidLineItem),
   };
 }

--- a/backend/orders/types.ts
+++ b/backend/orders/types.ts
@@ -40,5 +40,7 @@ export interface PaidOrderFacts {
   shippingMethod: string | null;
   shippingAddress: ShippingAddress;
   paymentMethod: string | null;
+  /** Customer delivery instructions, already trimmed at checkout. */
+  note: string | null;
   lineItems: PaidLineItem[];
 }

--- a/backend/prisma/migrations/20260711073109_add_order_note/migration.sql
+++ b/backend/prisma/migrations/20260711073109_add_order_note/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Order" ADD COLUMN     "note" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,7 @@ model Order {
   paymentMethod     String?
   fulfillmentStatus String  @default("received")
   trackingNumber    String?
+  note              String?
   items             OrderItem[]
 }
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,10 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## PRs as a request surface
+
+No. External PRs are not triaged — this is a solo project with no outside contributors. `/triage` works issues only.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,5 +16,6 @@ export {
 } from "./shipping.ts";
 export type { ShippingMethod } from "./shipping.ts";
 export type { ShippingAddress } from "./shippingAddress.ts";
+export { ORDER_NOTE_MAX_LENGTH } from "./orderNote.ts";
 export { REVENUE_THRESHOLDS } from "./revenue.ts";
 export type { QuarterRevenue, QuarterRevenueThreshold } from "./revenue.ts";

--- a/packages/shared/src/orderNote.ts
+++ b/packages/shared/src/orderNote.ts
@@ -1,0 +1,8 @@
+/**
+ * Max length of the customer order note ("Uwagi do zamówienia").
+ * Travels through Stripe session metadata, whose per-value hard cap is 500
+ * characters — 300 leaves margin and keeps the note readable in the admin
+ * table and emails. Enforced server-side at checkout; the Cart textarea
+ * mirrors it via maxLength + counter.
+ */
+export const ORDER_NOTE_MAX_LENGTH = 300;

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -8,6 +8,7 @@ import {
   SHIPPING_METHOD_LABELS,
   SHIPPING_COSTS,
   FREE_SHIPPING_THRESHOLD,
+  ORDER_NOTE_MAX_LENGTH,
   calcShippingCost,
 } from "@sznyt/shared";
 import { validateAddress } from "../lib/checkout-validation";
@@ -39,6 +40,7 @@ function Cart() {
   const [regulaminAccepted, setRegulaminAccepted] = useState(false);
   const [shippingMethod, setShippingMethod] = useState<ShippingMethod | null>(null);
   const [paczkomatPoint, setPaczkomatPoint] = useState<PaczkomatPoint | null>(null);
+  const [note, setNote] = useState("");
   const [address, setAddress] = useState<CourierAddress>({
     firstName: "", lastName: "", street: "", postalCode: "", city: "", phone: "", email: "",
   });
@@ -100,6 +102,7 @@ function Cart() {
           userId,
           shippingMethod,
           shippingAddress,
+          ...(note.trim() ? { note: note.trim() } : {}),
         },
       });
       if (!data.url) throw new Error("Nie udało się otworzyć strony płatności");
@@ -328,6 +331,30 @@ function Cart() {
                   )}
                 </div>
               ))}
+            </div>
+          )}
+
+          {/* Order note */}
+          {shippingMethod && (
+            <div className="mt-6">
+              <label
+                htmlFor="order-note"
+                className="font-dm-sans text-xs text-secondary-text tracking-widest uppercase block mb-1"
+              >
+                Uwagi do zamówienia (opcjonalnie)
+              </label>
+              <textarea
+                id="order-note"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                maxLength={ORDER_NOTE_MAX_LENGTH}
+                rows={3}
+                placeholder="Np. kod do bramy, preferowane godziny doręczenia"
+                className="w-full border border-borders font-dm-sans text-sm text-near-black px-3 py-2 resize-y focus:outline-none focus:border-near-black placeholder:text-gray-400"
+              />
+              <p className="font-dm-sans text-xs text-secondary-text text-right mt-1">
+                {note.length}/{ORDER_NOTE_MAX_LENGTH}
+              </p>
             </div>
           )}
         </div>

--- a/src/pages/MyOrders.tsx
+++ b/src/pages/MyOrders.tsx
@@ -190,6 +190,13 @@ function MyOrders() {
                   </div>
                 )}
 
+                {/* Order note */}
+                {order.note && (
+                  <p className="font-dm-sans text-sm text-near-black">
+                    <span className="text-secondary-text">Uwagi:</span> {order.note}
+                  </p>
+                )}
+
                 <p className="font-dm-sans text-xs text-secondary-text tracking-widest uppercase group-hover:text-accent transition-colors self-end">
                   Szczegóły →
                 </p>

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -185,6 +185,16 @@ function OrderDetail() {
               <p className="font-dm-sans text-sm text-secondary-text">Brak danych</p>
             )}
           </div>
+
+          {/* Order note */}
+          {order.note && (
+            <div className="sm:col-span-2">
+              <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
+                Uwagi do zamówienia
+              </p>
+              <p className="font-dm-sans text-sm text-near-black">{order.note}</p>
+            </div>
+          )}
         </div>
 
         {/* Total */}

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -114,6 +114,9 @@ function AdminOrders() {
                 {order.shippingAddress
                   ? Object.values(order.shippingAddress).filter(Boolean).join(", ")
                   : "—"}
+                {order.note && (
+                  <p className="mt-1 text-accent font-medium">Uwagi: {order.note}</p>
+                )}
               </td>
               <td className="p-3 whitespace-nowrap">
                 {new Date(order.createdAt).toLocaleDateString("pl-PL")}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type Order = {
   paymentMethod: string | null;
   fulfillmentStatus: string;
   trackingNumber: string | null;
+  note: string | null;
   items: OrderItem[];
 };
 
@@ -56,6 +57,7 @@ export type AdminOrder = {
   shippingAddress: Record<string, string> | null;
   fulfillmentStatus: string;
   trackingNumber: string | null;
+  note: string | null;
 };
 
 export type CartItem = {


### PR DESCRIPTION
## Summary

Customer order note („Uwagi do zamówienia") end to end, per the grilled plan on the issue:

- Cart: optional textarea at the end of the *Dostawa* section (after a shipping method is picked), `maxLength` 300 with a live counter — never blocks checkout
- Server: `normalizeOrderNote` trims, collapses blank to null, rejects >300 chars with 400 (`ORDER_NOTE_MAX_LENGTH` shared in `@sznyt/shared`; Stripe metadata hard-caps values at 500)
- Travels as its own `metadata.note` key on the Stripe session → `stripeFacts` → `PaidOrderFacts.note` → persisted by `recordPaidOrder` (additive migration `Order.note String?`)
- Surfaces: admin new-order email (prominent meta row above the details), customer confirmation email, admin orders table (inside the Adres cell — no 9th column), OrderDetail + MyOrders

## Test plan

- [x] 51 backend unit tests (`npm test` in `backend/`) — note pass-through, validation edge cases, email rendering incl. prominence ordering and HTML escaping
- [x] 5 db-backed tests (`npm run test:db`) — note persisted, null when absent, existing invariants untouched
- [x] Lint, `tsc -b`, frontend build green
- [x] Manual: checkout with a note via Stripe CLI webhook → note visible in both emails, admin table, order views (verified by Adrian, 2026-07-12)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

