### PR TITLE
refactor: usePublicForm hook for the three public forms

### DIFF
--- a/src/hooks/usePublicForm.test.ts
+++ b/src/hooks/usePublicForm.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { submitPublicForm } from "./usePublicForm";
+import { ApiError } from "../lib/api";
+
+const FALLBACK = "Coś poszło nie tak.";
+
+function run(overrides: Partial<Parameters<typeof submitPublicForm>[0]> = {}) {
+  return submitPublicForm({
+    path: "/contact",
+    body: { name: "Jan" },
+    honeypot: "",
+    fallbackError: FALLBACK,
+    ...overrides,
+  });
+}
+
+describe("submitPublicForm", () => {
+  it("posts the body with the honeypot field appended and resolves to success", async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true });
+
+    const result = await run({ post });
+
+    expect(post).toHaveBeenCalledWith("/contact", {
+      method: "POST",
+      body: { name: "Jan", _hp: "" },
+    });
+    expect(result).toEqual({ outcome: "success" });
+  });
+
+  it("resolves to success without touching the network when the honeypot is filled", async () => {
+    const post = vi.fn();
+
+    const result = await run({ honeypot: "spam-bot", post });
+
+    expect(post).not.toHaveBeenCalled();
+    expect(result).toEqual({ outcome: "success" });
+  });
+
+  it("surfaces a server-provided ApiError message verbatim", async () => {
+    const post = vi.fn().mockRejectedValue(new ApiError("Podaj poprawny e-mail.", 400));
+
+    const result = await run({ post });
+
+    expect(result).toEqual({ outcome: "error", message: "Podaj poprawny e-mail." });
+  });
+
+  it("falls back to the form's copy when the ApiError has no message", async () => {
+    const post = vi.fn().mockRejectedValue(new ApiError("", 502));
+
+    const result = await run({ post });
+
+    expect(result).toEqual({ outcome: "error", message: FALLBACK });
+  });
+
+  it("falls back to the form's copy on non-API failures (network errors)", async () => {
+    const post = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+    const result = await run({ post });
+
+    expect(result).toEqual({ outcome: "error", message: FALLBACK });
+  });
+});

--- a/src/hooks/usePublicForm.ts
+++ b/src/hooks/usePublicForm.ts
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import type { ChangeEvent, CSSProperties } from "react";
+import { apiFetch, ApiError } from "../lib/api";
+
+export type PublicFormSubmitResult =
+  | { outcome: "success" }
+  | { outcome: "error"; message: string };
+
+type PostFn = (path: string, opts: { method: "POST"; body: unknown }) => Promise<unknown>;
+
+/**
+ * Submit lifecycle shared by the public forms (contact, return, complaint).
+ * A filled honeypot resolves to success without touching the network — bots
+ * get the same response as humans. Server-provided ApiError messages surface
+ * verbatim; anything else collapses to the form's fallback copy.
+ */
+export async function submitPublicForm(opts: {
+  path: string;
+  body: Record<string, unknown>;
+  honeypot: string;
+  fallbackError: string;
+  post?: PostFn;
+}): Promise<PublicFormSubmitResult> {
+  const { path, body, honeypot, fallbackError, post = apiFetch } = opts;
+  if (honeypot) return { outcome: "success" };
+  try {
+    await post(path, { method: "POST", body: { ...body, _hp: honeypot } });
+    return { outcome: "success" };
+  } catch (err) {
+    return {
+      outcome: "error",
+      message: err instanceof ApiError && err.message ? err.message : fallbackError,
+    };
+  }
+}
+
+const HONEYPOT_STYLE: CSSProperties = { display: "none" };
+
+/**
+ * Owns the state machine of a public form: honeypot, loading, success, error.
+ * The form keeps its own field state and calls `submit(body)`; spread
+ * `honeypotProps` onto a hidden input to arm the spam trap.
+ */
+export function usePublicForm(path: string, fallbackError: string) {
+  const [honeypot, setHoneypot] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(
+    body: Record<string, unknown>,
+    opts?: { onSuccess?: () => void },
+  ): Promise<void> {
+    setLoading(true);
+    setError(null);
+    const result = await submitPublicForm({ path, body, honeypot, fallbackError });
+    if (result.outcome === "success") {
+      setSuccess(true);
+      opts?.onSuccess?.();
+    } else {
+      setError(result.message);
+    }
+    setLoading(false);
+  }
+
+  const honeypotProps = {
+    type: "text",
+    value: honeypot,
+    onChange: (e: ChangeEvent<HTMLInputElement>) => setHoneypot(e.target.value),
+    "aria-hidden": true,
+    tabIndex: -1,
+    autoComplete: "off",
+    style: HONEYPOT_STYLE,
+  } as const;
+
+  return { honeypotProps, loading, success, error, submit };
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,37 +1,29 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
-import { apiFetch, ApiError } from "../lib/api";
+import { usePublicForm } from "../hooks/usePublicForm";
 
 function Contact() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
-  const [honeypot, setHoneypot] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { honeypotProps, loading, success, error, submit } = usePublicForm(
+    "/contact",
+    "Coś poszło nie tak. Spróbuj ponownie.",
+  );
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    if (honeypot) { setSuccess(true); return; }
-    setLoading(true);
-    try {
-      await apiFetch("/contact", {
-        method: "POST",
-        body: { name, email, message, _hp: honeypot },
-      });
-      setSuccess(true);
-      setName("");
-      setEmail("");
-      setMessage("");
-    } catch (err) {
-      setError(
-        err instanceof ApiError && err.message ? err.message : "Coś poszło nie tak. Spróbuj ponownie.",
-      );
-    } finally {
-      setLoading(false);
-    }
+    await submit(
+      { name, email, message },
+      {
+        onSuccess: () => {
+          setName("");
+          setEmail("");
+          setMessage("");
+        },
+      },
+    );
   }
 
   return (
@@ -62,15 +54,7 @@ function Contact() {
               Napisz do nas
             </p>
             <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-              <input
-                type="text"
-                value={honeypot}
-                onChange={(e) => setHoneypot(e.target.value)}
-                aria-hidden="true"
-                tabIndex={-1}
-                autoComplete="off"
-                style={{ display: "none" }}
-              />
+              <input {...honeypotProps} />
               <div className="flex flex-col gap-2">
                 <label className="font-dm-sans text-xs text-secondary-text tracking-widest uppercase">
                   Imię i nazwisko

--- a/src/pages/Zwroty.tsx
+++ b/src/pages/Zwroty.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
-import { apiFetch, ApiError } from "../lib/api";
+import { usePublicForm } from "../hooks/usePublicForm";
+
+const AFTERSALES_FALLBACK_ERROR =
+  "Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.";
 
 function ZwrotForm() {
   const [orderNumber, setOrderNumber] = useState("");
@@ -9,31 +12,14 @@ function ZwrotForm() {
   const [email, setEmail] = useState("");
   const [reason, setReason] = useState("");
   const [bankAccount, setBankAccount] = useState("");
-  const [honeypot, setHoneypot] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { honeypotProps, loading, success, error, submit } = usePublicForm(
+    "/zwrot",
+    AFTERSALES_FALLBACK_ERROR,
+  );
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    if (honeypot) { setSuccess(true); return; }
-    setLoading(true);
-    setError(null);
-    try {
-      await apiFetch("/zwrot", {
-        method: "POST",
-        body: { orderNumber, name, email, reason, bankAccount, _hp: honeypot },
-      });
-      setSuccess(true);
-    } catch (err) {
-      setError(
-        err instanceof ApiError && err.message
-          ? err.message
-          : "Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.",
-      );
-    } finally {
-      setLoading(false);
-    }
+    await submit({ orderNumber, name, email, reason, bankAccount });
   }
 
   if (success)
@@ -46,7 +32,7 @@ function ZwrotForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-      <input type="text" value={honeypot} onChange={(e) => setHoneypot(e.target.value)} aria-hidden="true" tabIndex={-1} autoComplete="off" style={{ display: "none" }} />
+      <input {...honeypotProps} />
       <p className="font-dm-sans text-sm text-secondary-text leading-relaxed">
         Wypełnij formularz, a my odeślemy Ci potwierdzenie z instrukcją zwrotu. Produkt odeślij na adres podany w potwierdzeniu.
       </p>
@@ -95,31 +81,14 @@ function ReklamacjaForm() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [description, setDescription] = useState("");
-  const [honeypot, setHoneypot] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { honeypotProps, loading, success, error, submit } = usePublicForm(
+    "/reklamacja",
+    AFTERSALES_FALLBACK_ERROR,
+  );
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    if (honeypot) { setSuccess(true); return; }
-    setLoading(true);
-    setError(null);
-    try {
-      await apiFetch("/reklamacja", {
-        method: "POST",
-        body: { orderNumber, name, email, description, _hp: honeypot },
-      });
-      setSuccess(true);
-    } catch (err) {
-      setError(
-        err instanceof ApiError && err.message
-          ? err.message
-          : "Coś poszło nie tak. Napisz bezpośrednio na kontakt@sznytdesign.pl.",
-      );
-    } finally {
-      setLoading(false);
-    }
+    await submit({ orderNumber, name, email, description });
   }
 
   if (success)
@@ -132,7 +101,7 @@ function ReklamacjaForm() {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-      <input type="text" value={honeypot} onChange={(e) => setHoneypot(e.target.value)} aria-hidden="true" tabIndex={-1} autoComplete="off" style={{ display: "none" }} />
+      <input {...honeypotProps} />
       <p className="font-dm-sans text-sm text-secondary-text leading-relaxed">
         Opisz problem i wyślij formularz. W odpowiedzi poprosimy o przesłanie dokumentacji zdjęciowej. Reklamację rozpatrzymy w ciągu 14 dni roboczych.
       </p>


### PR DESCRIPTION
## Summary
- New `src/hooks/usePublicForm.ts`: one hook owning the honeypot + submit-lifecycle state machine copied verbatim across the contact, return, and complaint forms (PR 1 of 2 for #50, per the triage decision).
- The submit core (`submitPublicForm`) is a pure function with an injectable `post` seam — honeypot short-circuit and ApiError-vs-fallback resolution are unit-tested without DOM tooling (5 co-located tests).
- All three call sites migrated: `Contact.tsx`, `ZwrotForm`, `ReklamacjaForm`. Net −47 lines in the pages.
- Only intended behavior change: Contact now clears a stale error when resubmitting (it previously kept showing the old error next to the success message); the other two forms already did this.

## Test plan
- [x] `npm test` — 95 passing, incl. 5 new `usePublicForm` tests
- [x] `tsc -b`, `eslint .` clean
- [x] Manual: contact form submitted against the dev backend — success message renders, fields clear; honeypot input absent from the a11y tree; Zwroty tabs render both migrated forms

Part of #50 (issue closes with PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)