### PR TITLE
refactor: OrderCard module for the order renderings

### DIFF
--- a/src/orders/OrderCard.tsx
+++ b/src/orders/OrderCard.tsx
@@ -5,7 +5,7 @@ import {
   PAYMENT_METHOD_LABELS,
 } from "@sznyt/shared";
 import type { Order, OrderItem } from "../types";
-import { formatOrderDate, formatRecipientLine } from "./formatting";
+import { formatOrderDate, formatPaczkomatLine, formatRecipientLine } from "./formatting";
 
 /**
  * The one presentational rendering of an Order for customer surfaces.
@@ -98,6 +98,8 @@ function SummaryCard({ order }: { order: Order }) {
   );
 }
 
+// Renders the list-entry *content* only — the enclosing <Link> in MyOrders
+// owns the layout (flex, gap) and the `group` class the hover states key on.
 function ListItem({ order }: { order: Order }) {
   const address = order.shippingAddress;
   const isPaczkomat = order.shippingMethod === "paczkomat";
@@ -146,9 +148,7 @@ function ListItem({ order }: { order: Order }) {
           </p>
           {address && (
             <p className="font-dm-sans text-sm text-near-black">
-              {isPaczkomat
-                ? `Paczkomat: ${address.code}${address.city ? `, ${address.city}` : ""}`
-                : formatRecipientLine(address)}
+              {isPaczkomat ? formatPaczkomatLine(address) : formatRecipientLine(address)}
             </p>
           )}
         </div>
@@ -233,7 +233,7 @@ function DetailBody({ order }: { order: Order }) {
             <div className="font-dm-sans text-sm text-near-black flex flex-col gap-1">
               <p className="font-medium">{SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}</p>
               {order.shippingMethod === "paczkomat" && address?.code && (
-                <p>Paczkomat: {address.code}{address.city ? `, ${address.city}` : ""}</p>
+                <p>{formatPaczkomatLine(address)}</p>
               )}
               {order.shippingMethod !== "paczkomat" && address && (
                 <>

--- a/src/orders/OrderCard.tsx
+++ b/src/orders/OrderCard.tsx
@@ -1,0 +1,293 @@
+import {
+  ORDER_STATUS_LABELS,
+  FULFILLMENT_LABELS,
+  SHIPPING_METHOD_LABELS,
+  PAYMENT_METHOD_LABELS,
+} from "@sznyt/shared";
+import type { Order, OrderItem } from "../types";
+import { formatOrderDate, formatRecipientLine } from "./formatting";
+
+/**
+ * The one presentational rendering of an Order for customer surfaces.
+ * Variants map to the three contexts that show an order:
+ * - "summary" — the confirmation card on /sukces
+ * - "list"    — one entry in the my-orders list
+ * - "detail"  — the full body of the order-detail page
+ * The admin table is a different projection (AdminOrder has no line items)
+ * and consumes ./formatting directly instead.
+ */
+export type OrderCardVariant = "summary" | "list" | "detail";
+
+// Labels come from the shared vocabulary; badge colors are presentation and stay here (ADR-0002).
+const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  paid:      { label: ORDER_STATUS_LABELS.paid,      dot: "bg-green-500" },
+  pending:   { label: ORDER_STATUS_LABELS.pending,   dot: "bg-amber-400" },
+  cancelled: { label: ORDER_STATUS_LABELS.cancelled, dot: "bg-red-500" },
+  failed:    { label: ORDER_STATUS_LABELS.failed,    dot: "bg-red-500" },
+};
+
+const FULFILLMENT_CONFIG: Record<string, { label: string; dot: string }> = {
+  received:   { label: FULFILLMENT_LABELS.received,   dot: "bg-amber-400" },
+  processing: { label: FULFILLMENT_LABELS.processing, dot: "bg-blue-400" },
+  shipped:    { label: FULFILLMENT_LABELS.shipped,    dot: "bg-green-500" },
+  delivered:  { label: FULFILLMENT_LABELS.delivered,  dot: "bg-green-700" },
+};
+
+const DELETED_PRODUCT_NAME = "Produkt usunięty";
+
+function StatusBadge({ status }: { status: string }) {
+  const config = STATUS_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} />
+      <span>{config.label}</span>
+    </span>
+  );
+}
+
+function FulfillmentBadge({ status, labelClassName }: { status: string; labelClassName?: string }) {
+  const config = FULFILLMENT_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
+  return (
+    <span className={`inline-flex items-center gap-2 ${labelClassName ?? ""}`}>
+      <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} />
+      <span>{config.label}</span>
+    </span>
+  );
+}
+
+function ItemThumb({ item, sizeClass }: { item: OrderItem; sizeClass: string }) {
+  if (!item.product?.imageUrl) return <div className={`${sizeClass} bg-borders shrink-0`} />;
+  return (
+    <div
+      className={`${sizeClass} bg-cover bg-center shrink-0`}
+      style={{ backgroundImage: `url(${item.product.imageUrl})` }}
+    />
+  );
+}
+
+function SummaryCard({ order }: { order: Order }) {
+  return (
+    <div className="border border-borders p-8 flex flex-col gap-4 w-full max-w-sm">
+      <div className="flex justify-between font-dm-sans text-near-black">
+        <span className="text-secondary-text">Numer zamówienia</span>
+        <span>#{order.id}</span>
+      </div>
+      <div className="flex justify-between font-dm-sans text-near-black">
+        <span className="text-secondary-text">Status</span>
+        <span>{ORDER_STATUS_LABELS[order.status] ?? order.status}</span>
+      </div>
+      <div className="flex justify-between font-dm-sans text-near-black">
+        <span className="text-secondary-text">Data</span>
+        <span>{formatOrderDate(order.createdAt)}</span>
+      </div>
+
+      <div className="border-t border-borders pt-4 flex flex-col gap-3">
+        {order.items?.map((item) => (
+          <div key={item.id} className="flex justify-between font-dm-sans text-near-black text-sm">
+            <span>{item.product?.name ?? DELETED_PRODUCT_NAME} × {item.quantity}</span>
+            <span>{item.price * item.quantity} PLN</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="border-t border-borders pt-4 flex justify-between font-dm-sans text-near-black font-medium">
+        <span>Suma</span>
+        <span>{order.total} PLN</span>
+      </div>
+    </div>
+  );
+}
+
+function ListItem({ order }: { order: Order }) {
+  const address = order.shippingAddress;
+  const isPaczkomat = order.shippingMethod === "paczkomat";
+
+  return (
+    <>
+      {/* Header row */}
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 sm:gap-0">
+        <div>
+          <p className="font-cormorant text-2xl text-near-black font-light group-hover:text-accent transition-colors">
+            Zamówienie #{order.id}
+          </p>
+          <p className="font-dm-sans text-sm text-secondary-text mt-1">
+            {formatOrderDate(order.createdAt)} · <StatusBadge status={order.status} />
+          </p>
+          <FulfillmentBadge
+            status={order.fulfillmentStatus}
+            labelClassName="font-dm-sans text-sm text-secondary-text mt-0.5"
+          />
+        </div>
+        <p className="font-cormorant text-2xl text-near-black font-light">
+          {order.total} PLN
+        </p>
+      </div>
+
+      {/* Products */}
+      {order.items && order.items.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {order.items.map((item) => (
+            <div key={item.id} className="flex items-center gap-3">
+              <ItemThumb item={item} sizeClass="w-10 h-10" />
+              <p className="font-dm-sans text-sm text-secondary-text">
+                {item.product?.name ?? DELETED_PRODUCT_NAME}{" "}
+                <span className="text-near-black">× {item.quantity}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Shipping */}
+      {order.shippingMethod && (
+        <div className="flex flex-col gap-1">
+          <p className="font-dm-sans text-xs text-accent tracking-[0.2em] uppercase">
+            {SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}
+          </p>
+          {address && (
+            <p className="font-dm-sans text-sm text-near-black">
+              {isPaczkomat
+                ? `Paczkomat: ${address.code}${address.city ? `, ${address.city}` : ""}`
+                : formatRecipientLine(address)}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Order note */}
+      {order.note && (
+        <p className="font-dm-sans text-sm text-near-black">
+          <span className="text-secondary-text">Uwagi:</span> {order.note}
+        </p>
+      )}
+
+      <p className="font-dm-sans text-xs text-secondary-text tracking-widest uppercase group-hover:text-accent transition-colors self-end">
+        Szczegóły →
+      </p>
+    </>
+  );
+}
+
+function DetailBody({ order }: { order: Order }) {
+  const address = order.shippingAddress;
+
+  return (
+    <>
+      <h1 className="font-cormorant text-3xl md:text-5xl text-near-black font-light mb-2">
+        Zamówienie #{order.id}
+      </h1>
+      <p className="font-dm-sans text-sm text-secondary-text mb-4">
+        {formatOrderDate(order.createdAt)} · <StatusBadge status={order.status} />
+      </p>
+      <div className="flex flex-col gap-1 mb-12">
+        <FulfillmentBadge
+          status={order.fulfillmentStatus}
+          labelClassName="font-dm-sans text-sm text-near-black"
+        />
+        {order.trackingNumber && (
+          <p className="font-dm-sans text-xs text-secondary-text">
+            Nr przesyłki: <span className="text-near-black font-medium">{order.trackingNumber}</span>
+          </p>
+        )}
+      </div>
+
+      {/* Products */}
+      <div className="flex flex-col divide-y divide-borders mb-12">
+        {order.items?.map((item) => (
+          <div key={item.id} className="flex gap-4 md:gap-6 py-6 items-center">
+            <ItemThumb item={item} sizeClass="w-14 h-14 md:w-20 md:h-20" />
+            <div className="flex-1 min-w-0">
+              <p className="font-cormorant text-lg md:text-xl text-near-black font-light">
+                {item.product?.name ?? DELETED_PRODUCT_NAME}
+              </p>
+              <p className="font-dm-sans text-sm text-secondary-text">
+                {item.quantity} szt. × {item.price} PLN
+              </p>
+            </div>
+            <p className="font-cormorant text-lg md:text-xl text-near-black font-light w-20 md:w-28 text-right">
+              {item.price * item.quantity} PLN
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 md:gap-10">
+        {/* Payment method */}
+        {order.paymentMethod && (
+          <div className="sm:col-span-2">
+            <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
+              Płatność
+            </p>
+            <p className="font-dm-sans text-sm text-near-black font-medium">
+              {PAYMENT_METHOD_LABELS[order.paymentMethod] ?? order.paymentMethod}
+            </p>
+          </div>
+        )}
+
+        {/* Shipping info */}
+        <div>
+          <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
+            Dostawa
+          </p>
+          {order.shippingMethod ? (
+            <div className="font-dm-sans text-sm text-near-black flex flex-col gap-1">
+              <p className="font-medium">{SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}</p>
+              {order.shippingMethod === "paczkomat" && address?.code && (
+                <p>Paczkomat: {address.code}{address.city ? `, ${address.city}` : ""}</p>
+              )}
+              {order.shippingMethod !== "paczkomat" && address && (
+                <>
+                  {address.street && <p>{address.street}</p>}
+                  {address.postalCode && <p>{address.postalCode} {address.city}</p>}
+                </>
+              )}
+            </div>
+          ) : (
+            <p className="font-dm-sans text-sm text-secondary-text">Brak danych</p>
+          )}
+        </div>
+
+        {/* Address */}
+        <div>
+          <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
+            Dane odbiorcy
+          </p>
+          {address ? (
+            <div className="font-dm-sans text-sm text-near-black flex flex-col gap-1">
+              {address.firstName && <p>{address.firstName} {address.lastName}</p>}
+              {address.street && <p>{address.street}</p>}
+              {address.postalCode && <p>{address.postalCode} {address.city}</p>}
+              {address.phone && <p>{address.phone}</p>}
+            </div>
+          ) : (
+            <p className="font-dm-sans text-sm text-secondary-text">Brak danych</p>
+          )}
+        </div>
+
+        {/* Order note */}
+        {order.note && (
+          <div className="sm:col-span-2">
+            <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
+              Uwagi do zamówienia
+            </p>
+            <p className="font-dm-sans text-sm text-near-black">{order.note}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Total */}
+      <div className="border-t border-borders mt-10 pt-6 flex justify-between items-center">
+        <p className="font-dm-sans text-sm text-secondary-text tracking-widest uppercase">Suma</p>
+        <p className="font-cormorant text-3xl text-near-black font-light">{order.total} PLN</p>
+      </div>
+    </>
+  );
+}
+
+function OrderCard({ order, variant }: { order: Order; variant: OrderCardVariant }) {
+  if (variant === "summary") return <SummaryCard order={order} />;
+  if (variant === "list") return <ListItem order={order} />;
+  return <DetailBody order={order} />;
+}
+
+export default OrderCard;

--- a/src/orders/formatting.test.ts
+++ b/src/orders/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatOrderDate, formatRecipientLine } from "./formatting";
+import { formatOrderDate, formatPaczkomatLine, formatRecipientLine } from "./formatting";
 
 describe("formatOrderDate", () => {
   it("renders an ISO timestamp as a Polish date", () => {
@@ -31,5 +31,17 @@ describe("formatRecipientLine", () => {
 
   it("returns an empty string for an empty address", () => {
     expect(formatRecipientLine({})).toBe("");
+  });
+});
+
+describe("formatPaczkomatLine", () => {
+  it("shows the point code with its city", () => {
+    expect(formatPaczkomatLine({ code: "KRA010", city: "Kraków" })).toBe(
+      "Paczkomat: KRA010, Kraków",
+    );
+  });
+
+  it("omits the city when absent", () => {
+    expect(formatPaczkomatLine({ code: "KRA010" })).toBe("Paczkomat: KRA010");
   });
 });

--- a/src/orders/formatting.test.ts
+++ b/src/orders/formatting.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { formatOrderDate, formatRecipientLine } from "./formatting";
+
+describe("formatOrderDate", () => {
+  it("renders an ISO timestamp as a Polish date", () => {
+    expect(formatOrderDate("2026-07-12T09:30:00.000Z")).toBe("12.07.2026");
+  });
+});
+
+describe("formatRecipientLine", () => {
+  it("joins full recipient data into one comma-separated line", () => {
+    expect(
+      formatRecipientLine({
+        firstName: "Jan",
+        lastName: "Kowalski",
+        street: "Lipowa 5",
+        postalCode: "70-001",
+        city: "Szczecin",
+        phone: "600100200",
+      }),
+    ).toBe("Jan Kowalski, Lipowa 5, 70-001 Szczecin, 600100200");
+  });
+
+  it("falls back to the bare city when the postal code is missing", () => {
+    expect(formatRecipientLine({ city: "Szczecin" })).toBe("Szczecin");
+  });
+
+  it("omits the name unless both first and last name are present", () => {
+    expect(formatRecipientLine({ firstName: "Jan", street: "Lipowa 5" })).toBe("Lipowa 5");
+  });
+
+  it("returns an empty string for an empty address", () => {
+    expect(formatRecipientLine({})).toBe("");
+  });
+});

--- a/src/orders/formatting.ts
+++ b/src/orders/formatting.ts
@@ -1,0 +1,26 @@
+// Pure order-presentation formatters shared by every surface that renders
+// an order (customer pages via OrderCard, the admin table directly).
+
+export function formatOrderDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("pl-PL");
+}
+
+/**
+ * One-line recipient summary for compact contexts (order list items).
+ * Name appears only when complete; a bare city stands in for a missing
+ * postal code — mirrors what checkout can actually produce.
+ */
+export function formatRecipientLine(address: Record<string, string>): string {
+  return [
+    address.firstName && address.lastName
+      ? `${address.firstName} ${address.lastName}`
+      : null,
+    address.street,
+    address.postalCode && address.city
+      ? `${address.postalCode} ${address.city}`
+      : address.city,
+    address.phone,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}

--- a/src/orders/formatting.ts
+++ b/src/orders/formatting.ts
@@ -1,5 +1,9 @@
+import type { ShippingAddress } from "@sznyt/shared";
+
 // Pure order-presentation formatters shared by every surface that renders
 // an order (customer pages via OrderCard, the admin table directly).
+// Addresses arrive as API JSON, so fields are Partial — the shipping
+// address contract guarantees them, the wire format doesn't.
 
 export function formatOrderDate(iso: string): string {
   return new Date(iso).toLocaleDateString("pl-PL");
@@ -10,7 +14,7 @@ export function formatOrderDate(iso: string): string {
  * Name appears only when complete; a bare city stands in for a missing
  * postal code — mirrors what checkout can actually produce.
  */
-export function formatRecipientLine(address: Record<string, string>): string {
+export function formatRecipientLine(address: Partial<ShippingAddress>): string {
   return [
     address.firstName && address.lastName
       ? `${address.firstName} ${address.lastName}`
@@ -23,4 +27,9 @@ export function formatRecipientLine(address: Record<string, string>): string {
   ]
     .filter(Boolean)
     .join(", ");
+}
+
+/** Paczkomat point summary, e.g. "Paczkomat: KRA010, Kraków". */
+export function formatPaczkomatLine(address: Partial<ShippingAddress>): string {
+  return `Paczkomat: ${address.code ?? ""}${address.city ? `, ${address.city}` : ""}`;
 }

--- a/src/pages/MyOrders.tsx
+++ b/src/pages/MyOrders.tsx
@@ -1,38 +1,13 @@
 import { RedirectToSignIn, useAuth } from "@clerk/react";
-import { ORDER_STATUS_LABELS, FULFILLMENT_LABELS, SHIPPING_METHOD_LABELS } from "@sznyt/shared";
 import { useResource } from "../hooks/useResource";
 import type { Order } from "../types";
 import Skeleton from "../components/Skeleton";
 import { Link } from "react-router-dom";
 import Seo from "../components/Seo";
+import OrderCard from "../orders/OrderCard";
 
 const MY_ORDERS_DESCRIPTION =
   "Historia i status Twoich zamówień w Sznyt Design — sprawdź szczegóły dostawy i numer śledzenia przesyłki.";
-
-// Labels come from the shared vocabulary; badge colors are presentation and stay here (ADR-0002).
-const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
-  paid:      { label: ORDER_STATUS_LABELS.paid,      dot: "bg-green-500" },
-  pending:   { label: ORDER_STATUS_LABELS.pending,   dot: "bg-amber-400" },
-  cancelled: { label: ORDER_STATUS_LABELS.cancelled, dot: "bg-red-500" },
-  failed:    { label: ORDER_STATUS_LABELS.failed,    dot: "bg-red-500" },
-};
-
-const FULFILLMENT_CONFIG: Record<string, { label: string; dot: string }> = {
-  received:   { label: FULFILLMENT_LABELS.received,   dot: "bg-amber-400" },
-  processing: { label: FULFILLMENT_LABELS.processing, dot: "bg-blue-400" },
-  shipped:    { label: FULFILLMENT_LABELS.shipped,    dot: "bg-green-500" },
-  delivered:  { label: FULFILLMENT_LABELS.delivered,  dot: "bg-green-700" },
-};
-
-function StatusBadge({ status }: { status: string }) {
-  const config = STATUS_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} />
-      <span>{config.label}</span>
-    </span>
-  );
-}
 
 function MyOrders() {
   const { userId, isLoaded } = useAuth();
@@ -100,109 +75,15 @@ function MyOrders() {
         </h1>
 
         <div className="flex flex-col divide-y divide-borders">
-          {orders.map((order) => {
-            const address = order.shippingAddress;
-            const isPaczkomat = order.shippingMethod === "paczkomat";
-
-            return (
-              <Link
-                key={order.id}
-                to={`/moje-zamowienia/${order.id}`}
-                className="py-8 flex flex-col gap-4 group"
-              >
-                {/* Header row */}
-                <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 sm:gap-0">
-                  <div>
-                    <p className="font-cormorant text-2xl text-near-black font-light group-hover:text-accent transition-colors">
-                      Zamówienie #{order.id}
-                    </p>
-                    <p className="font-dm-sans text-sm text-secondary-text mt-1">
-                      {new Date(order.createdAt).toLocaleDateString("pl-PL")} · <StatusBadge status={order.status} />
-                    </p>
-                    {(() => {
-                      const fc = FULFILLMENT_CONFIG[order.fulfillmentStatus] ?? { label: order.fulfillmentStatus, dot: "bg-gray-400" };
-                      return (
-                        <span className="inline-flex items-center gap-2 font-dm-sans text-sm text-secondary-text mt-0.5">
-                          <span className={`w-2 h-2 rounded-full shrink-0 ${fc.dot}`} />
-                          {fc.label}
-                        </span>
-                      );
-                    })()}
-                  </div>
-                  <p className="font-cormorant text-2xl text-near-black font-light">
-                    {order.total} PLN
-                  </p>
-                </div>
-
-                {/* Products */}
-                {order.items && order.items.length > 0 && (
-                  <div className="flex flex-col gap-2">
-                    {order.items.map((item) => (
-                      <div key={item.id} className="flex items-center gap-3">
-                        {item.product?.imageUrl ? (
-                          <div
-                            className="w-10 h-10 bg-cover bg-center shrink-0"
-                            style={{ backgroundImage: `url(${item.product.imageUrl})` }}
-                          />
-                        ) : (
-                          <div className="w-10 h-10 bg-borders shrink-0" />
-                        )}
-                        <p className="font-dm-sans text-sm text-secondary-text">
-                          {item.product?.name ?? "Produkt usunięty"}{" "}
-                          <span className="text-near-black">× {item.quantity}</span>
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
-                {/* Shipping */}
-                {order.shippingMethod && (
-                  <div className="flex flex-col gap-1">
-                    <p className="font-dm-sans text-xs text-accent tracking-[0.2em] uppercase">
-                      {SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}
-                    </p>
-                    {address && (
-                      <>
-                        {isPaczkomat ? (
-                          <p className="font-dm-sans text-sm text-near-black">
-                            Paczkomat: {address.code}
-                            {address.city ? `, ${address.city}` : ""}
-                          </p>
-                        ) : (
-                          <p className="font-dm-sans text-sm text-near-black">
-                            {[
-                              address.firstName && address.lastName
-                                ? `${address.firstName} ${address.lastName}`
-                                : null,
-                              address.street,
-                              address.postalCode && address.city
-                                ? `${address.postalCode} ${address.city}`
-                                : address.city,
-                              address.phone,
-                            ]
-                              .filter(Boolean)
-                              .join(", ")}
-                          </p>
-                        )}
-                      </>
-                    )}
-                  </div>
-                )}
-
-                {/* Order note */}
-                {order.note && (
-                  <p className="font-dm-sans text-sm text-near-black">
-                    <span className="text-secondary-text">Uwagi:</span> {order.note}
-                  </p>
-                )}
-
-                <p className="font-dm-sans text-xs text-secondary-text tracking-widest uppercase group-hover:text-accent transition-colors self-end">
-                  Szczegóły →
-                </p>
-              </Link>
-            );
-          })}
+          {orders.map((order) => (
+            <Link
+              key={order.id}
+              to={`/moje-zamowienia/${order.id}`}
+              className="py-8 flex flex-col gap-4 group"
+            >
+              <OrderCard order={order} variant="list" />
+            </Link>
+          ))}
         </div>
       </div>
     </main>

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -1,52 +1,12 @@
 import { useParams, Link, Navigate } from "react-router-dom";
 import { useAuth } from "@clerk/react";
-import {
-  ORDER_STATUS_LABELS,
-  FULFILLMENT_LABELS,
-  SHIPPING_METHOD_LABELS,
-  PAYMENT_METHOD_LABELS,
-} from "@sznyt/shared";
 import type { Order } from "../types";
 import Seo from "../components/Seo";
 import { useResource } from "../hooks/useResource";
+import OrderCard from "../orders/OrderCard";
 
 const ORDER_DETAIL_DESCRIPTION =
   "Podgląd zamówienia w Sznyt Design — pozycje, adres dostawy, sposób płatności i status realizacji.";
-
-// Labels come from the shared vocabulary; badge colors are presentation and stay here (ADR-0002).
-const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
-  paid:      { label: ORDER_STATUS_LABELS.paid,      dot: "bg-green-500" },
-  pending:   { label: ORDER_STATUS_LABELS.pending,   dot: "bg-amber-400" },
-  cancelled: { label: ORDER_STATUS_LABELS.cancelled, dot: "bg-red-500" },
-  failed:    { label: ORDER_STATUS_LABELS.failed,    dot: "bg-red-500" },
-};
-
-const FULFILLMENT_CONFIG: Record<string, { label: string; dot: string }> = {
-  received:   { label: FULFILLMENT_LABELS.received,   dot: "bg-amber-400" },
-  processing: { label: FULFILLMENT_LABELS.processing, dot: "bg-blue-400" },
-  shipped:    { label: FULFILLMENT_LABELS.shipped,    dot: "bg-green-500" },
-  delivered:  { label: FULFILLMENT_LABELS.delivered,  dot: "bg-green-700" },
-};
-
-function StatusBadge({ status }: { status: string }) {
-  const config = STATUS_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} />
-      <span>{config.label}</span>
-    </span>
-  );
-}
-
-function FulfillmentBadge({ status }: { status: string }) {
-  const config = FULFILLMENT_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span className={`w-2 h-2 rounded-full shrink-0 ${config.dot}`} />
-      <span className="font-dm-sans text-sm text-near-black">{config.label}</span>
-    </span>
-  );
-}
 
 function OrderDetail() {
   const { id } = useParams();
@@ -76,8 +36,6 @@ function OrderDetail() {
       </main>
     );
 
-  const address = order.shippingAddress;
-
   return (
     <main className="min-h-screen bg-warm-white px-6 py-16">
       <Seo title={`Zamówienie #${order.id}`} description={ORDER_DETAIL_DESCRIPTION} />
@@ -91,117 +49,7 @@ function OrderDetail() {
           ← Moje zamówienia
         </Link>
 
-        <h1 className="font-cormorant text-3xl md:text-5xl text-near-black font-light mb-2">
-          Zamówienie #{order.id}
-        </h1>
-        <p className="font-dm-sans text-sm text-secondary-text mb-4">
-          {new Date(order.createdAt).toLocaleDateString("pl-PL")} · <StatusBadge status={order.status} />
-        </p>
-        <div className="flex flex-col gap-1 mb-12">
-          <FulfillmentBadge status={order.fulfillmentStatus} />
-          {order.trackingNumber && (
-            <p className="font-dm-sans text-xs text-secondary-text">
-              Nr przesyłki: <span className="text-near-black font-medium">{order.trackingNumber}</span>
-            </p>
-          )}
-        </div>
-
-        {/* Products */}
-        <div className="flex flex-col divide-y divide-borders mb-12">
-          {order.items?.map((item) => (
-            <div key={item.id} className="flex gap-4 md:gap-6 py-6 items-center">
-              {item.product?.imageUrl ? (
-                <div
-                  className="w-14 h-14 md:w-20 md:h-20 bg-cover bg-center shrink-0"
-                  style={{ backgroundImage: `url(${item.product.imageUrl})` }}
-                />
-              ) : (
-                <div className="w-14 h-14 md:w-20 md:h-20 bg-borders shrink-0" />
-              )}
-              <div className="flex-1 min-w-0">
-                <p className="font-cormorant text-lg md:text-xl text-near-black font-light">
-                  {item.product?.name ?? "Produkt usunięty"}
-                </p>
-                <p className="font-dm-sans text-sm text-secondary-text">
-                  {item.quantity} szt. × {item.price} PLN
-                </p>
-              </div>
-              <p className="font-cormorant text-lg md:text-xl text-near-black font-light w-20 md:w-28 text-right">
-                {item.price * item.quantity} PLN
-              </p>
-            </div>
-          ))}
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 md:gap-10">
-          {/* Payment method */}
-          {order.paymentMethod && (
-            <div className="sm:col-span-2">
-              <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
-                Płatność
-              </p>
-              <p className="font-dm-sans text-sm text-near-black font-medium">
-                {PAYMENT_METHOD_LABELS[order.paymentMethod] ?? order.paymentMethod}
-              </p>
-            </div>
-          )}
-
-          {/* Shipping info */}
-          <div>
-            <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
-              Dostawa
-            </p>
-            {order.shippingMethod ? (
-              <div className="font-dm-sans text-sm text-near-black flex flex-col gap-1">
-                <p className="font-medium">{SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}</p>
-                {order.shippingMethod === "paczkomat" && address?.code && (
-                  <p>Paczkomat: {address.code}{address.city ? `, ${address.city}` : ""}</p>
-                )}
-                {order.shippingMethod !== "paczkomat" && address && (
-                  <>
-                    {address.street && <p>{address.street}</p>}
-                    {address.postalCode && <p>{address.postalCode} {address.city}</p>}
-                  </>
-                )}
-              </div>
-            ) : (
-              <p className="font-dm-sans text-sm text-secondary-text">Brak danych</p>
-            )}
-          </div>
-
-          {/* Address */}
-          <div>
-            <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
-              Dane odbiorcy
-            </p>
-            {address ? (
-              <div className="font-dm-sans text-sm text-near-black flex flex-col gap-1">
-                {address.firstName && <p>{address.firstName} {address.lastName}</p>}
-                {address.street && <p>{address.street}</p>}
-                {address.postalCode && <p>{address.postalCode} {address.city}</p>}
-                {address.phone && <p>{address.phone}</p>}
-              </div>
-            ) : (
-              <p className="font-dm-sans text-sm text-secondary-text">Brak danych</p>
-            )}
-          </div>
-
-          {/* Order note */}
-          {order.note && (
-            <div className="sm:col-span-2">
-              <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">
-                Uwagi do zamówienia
-              </p>
-              <p className="font-dm-sans text-sm text-near-black">{order.note}</p>
-            </div>
-          )}
-        </div>
-
-        {/* Total */}
-        <div className="border-t border-borders mt-10 pt-6 flex justify-between items-center">
-          <p className="font-dm-sans text-sm text-secondary-text tracking-widest uppercase">Suma</p>
-          <p className="font-cormorant text-3xl text-near-black font-light">{order.total} PLN</p>
-        </div>
+        <OrderCard order={order} variant="detail" />
       </div>
     </main>
   );

--- a/src/pages/OrderSuccess.tsx
+++ b/src/pages/OrderSuccess.tsx
@@ -6,6 +6,7 @@ import { Show } from "@clerk/react";
 import { useCart } from "../hooks/useCart";
 import Seo from "../components/Seo";
 import { apiFetch } from "../lib/api";
+import OrderCard from "../orders/OrderCard";
 
 function OrderSuccess() {
   const [searchParams] = useSearchParams();
@@ -82,34 +83,7 @@ function OrderSuccess() {
         Dziękujemy za zamówienie!
       </h1>
 
-      <div className="border border-borders p-8 flex flex-col gap-4 w-full max-w-sm">
-        <div className="flex justify-between font-dm-sans text-near-black">
-          <span className="text-secondary-text">Numer zamówienia</span>
-          <span>#{order.id}</span>
-        </div>
-        <div className="flex justify-between font-dm-sans text-near-black">
-          <span className="text-secondary-text">Status</span>
-          <span>{order.status === "paid" ? "Opłacone" : order.status}</span>
-        </div>
-        <div className="flex justify-between font-dm-sans text-near-black">
-          <span className="text-secondary-text">Data</span>
-          <span>{new Date(order.createdAt).toLocaleDateString("pl-PL")}</span>
-        </div>
-
-        <div className="border-t border-borders pt-4 flex flex-col gap-3">
-          {order.items?.map((item) => (
-            <div key={item.id} className="flex justify-between font-dm-sans text-near-black text-sm">
-              <span>{item.product?.name ?? "Produkt usunięty"} × {item.quantity}</span>
-              <span>{item.price * item.quantity} PLN</span>
-            </div>
-          ))}
-        </div>
-
-        <div className="border-t border-borders pt-4 flex justify-between font-dm-sans text-near-black font-medium">
-          <span>Suma</span>
-          <span>{order.total} PLN</span>
-        </div>
-      </div>
+      <OrderCard order={order} variant="summary" />
 
       <div className="flex flex-col sm:flex-row gap-4">
         <Show when="signed-in">

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@clerk/react";
 import Skeleton from "../../components/Skeleton";
 import { apiFetch } from "../../lib/api";
 import { useResource } from "../../hooks/useResource";
+import { formatOrderDate } from "../../orders/formatting";
 
 function FulfillmentCell({ order }: { order: AdminOrder }) {
   const { getToken } = useAuth();
@@ -119,7 +120,7 @@ function AdminOrders() {
                 )}
               </td>
               <td className="p-3 whitespace-nowrap">
-                {new Date(order.createdAt).toLocaleDateString("pl-PL")}
+                {formatOrderDate(order.createdAt)}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- New `src/orders/` module (PR 2 of 2 for #50, per the triage decision): `OrderCard` is the one presentational rendering of an Order for customer surfaces, with variants mapping to the three contexts — `summary` (/sukces card), `list` (my-orders entry), `detail` (order-detail body). Markup moved verbatim; net −296 lines in the pages.
- The duplicated `STATUS_CONFIG` / `FULFILLMENT_CONFIG` blocks and badge components from `OrderDetail` and `MyOrders` now exist once, inside the module; labels still come from `@sznyt/shared`, colors stay frontend per ADR-0002.
- Pure formatters (`formatOrderDate`, `formatRecipientLine`) extracted to `src/orders/formatting.ts` with co-located tests.
- **Design call on the admin table:** the triage note asks for all four renderings, but `AdminOrders` renders an `AdminOrder`, which has no `items` relation — `OrderCard` literally cannot render it, and a card component returning a `<tr>` would corrupt either the table or the component. The admin row therefore consumes the module's formatters and keeps its table markup. Flagged in the issue comment; easy to revisit when #24 (admin order detail page) lands, which *will* be able to reuse `variant="detail"`.
- Only intended pixel-level deviation: the /sukces status line now uses `ORDER_STATUS_LABELS` instead of an inline `"paid" → "Opłacone"` ternary — identical output for every status the page can actually receive.

## Test plan
- [x] `npm test` — 95 passing, incl. 5 new formatting tests
- [x] `tsc -b`, `eslint .` clean
- [x] Manual: /sukces rendered against a real paid order (id, status, items, total all correct)
- [ ] Manual (needs Clerk login): /moje-zamowienia list + order detail render unchanged

Closes #50 (PR 1 is #64 — merge both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)