### PR TITLE
fix: revert fulfillment controls and show error on failed save

### DIFF
--- a/src/orders/fulfillmentSave.test.ts
+++ b/src/orders/fulfillmentSave.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createFulfillmentSaver,
+  fulfillmentSaveReducer,
+  initFulfillmentSave,
+  FULFILLMENT_SAVE_ERROR,
+  type FulfillmentDraft,
+  type FulfillmentSaveState,
+} from "./fulfillmentSave";
+
+const persisted: FulfillmentDraft = { status: "received", tracking: "" };
+
+describe("fulfillmentSaveReducer", () => {
+  it("reverts the draft to the last persisted values and shows an error when a save fails", () => {
+    let state = initFulfillmentSave(persisted);
+    state = fulfillmentSaveReducer(state, {
+      type: "edit",
+      draft: { status: "shipped", tracking: "PX123" },
+    });
+    state = fulfillmentSaveReducer(state, { type: "saveStart" });
+
+    state = fulfillmentSaveReducer(state, { type: "saveFailure" });
+
+    expect(state.draft).toEqual({ status: "received", tracking: "" });
+    expect(state.error).toBe(FULFILLMENT_SAVE_ERROR);
+    expect(state.saving).toBe(false);
+  });
+
+  it("clears the error and advances the revert target on a successful save", () => {
+    let state = initFulfillmentSave(persisted);
+    state = fulfillmentSaveReducer(state, { type: "saveFailure" });
+
+    const saved: FulfillmentDraft = { status: "shipped", tracking: "PX123" };
+    state = fulfillmentSaveReducer(state, {
+      type: "edit",
+      draft: saved,
+    });
+    state = fulfillmentSaveReducer(state, { type: "saveStart" });
+    state = fulfillmentSaveReducer(state, { type: "saveSuccess", saved });
+
+    expect(state.error).toBeNull();
+    expect(state.saving).toBe(false);
+    expect(state.persisted).toEqual(saved);
+
+    // a later failure now reverts to the newly confirmed values, not the originals
+    state = fulfillmentSaveReducer(state, {
+      type: "edit",
+      draft: { status: "received", tracking: "PX123" },
+    });
+    state = fulfillmentSaveReducer(state, { type: "saveFailure" });
+    expect(state.draft).toEqual(saved);
+  });
+
+  it("keeps edits typed while a save is in flight when that save succeeds", () => {
+    let state = initFulfillmentSave(persisted);
+    const saved: FulfillmentDraft = { status: "received", tracking: "PX1" };
+    state = fulfillmentSaveReducer(state, { type: "edit", draft: saved });
+    state = fulfillmentSaveReducer(state, { type: "saveStart" });
+    state = fulfillmentSaveReducer(state, {
+      type: "edit",
+      draft: { status: "received", tracking: "PX12" },
+    });
+
+    state = fulfillmentSaveReducer(state, { type: "saveSuccess", saved });
+
+    expect(state.draft).toEqual({ status: "received", tracking: "PX12" });
+    expect(state.persisted).toEqual(saved);
+  });
+});
+
+describe("createFulfillmentSaver", () => {
+  function harness(patch: (draft: FulfillmentDraft) => Promise<unknown>) {
+    let state: FulfillmentSaveState = initFulfillmentSave(persisted);
+    const save = createFulfillmentSaver(patch, (action) => {
+      state = fulfillmentSaveReducer(state, action);
+    });
+    // mirrors the component: controls dispatch an edit, then trigger the save
+    function editAndSave(draft: FulfillmentDraft) {
+      state = fulfillmentSaveReducer(state, { type: "edit", draft });
+      return save(draft);
+    }
+    return { editAndSave, getState: () => state };
+  }
+
+  it("commits the saved draft when the PATCH resolves", async () => {
+    const { editAndSave, getState } = harness(() => Promise.resolve());
+    const draft: FulfillmentDraft = { status: "shipped", tracking: "PX123" };
+
+    await editAndSave(draft);
+
+    expect(getState().persisted).toEqual(draft);
+    expect(getState().draft).toEqual(draft);
+    expect(getState().error).toBeNull();
+  });
+
+  it("reverts and surfaces the error when the PATCH rejects", async () => {
+    const { editAndSave, getState } = harness(() => Promise.reject(new Error("boom")));
+
+    await editAndSave({ status: "shipped", tracking: "PX123" });
+
+    expect(getState().draft).toEqual(persisted);
+    expect(getState().error).toBe(FULFILLMENT_SAVE_ERROR);
+    expect(getState().saving).toBe(false);
+  });
+
+  it("ignores a stale failure that resolves after a newer save succeeded", async () => {
+    let failFirst: (reason: Error) => void = () => {};
+    const patch = vi
+      .fn<(draft: FulfillmentDraft) => Promise<unknown>>()
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => { failFirst = reject; }),
+      )
+      .mockResolvedValueOnce(undefined);
+    const { editAndSave, getState } = harness(patch);
+
+    const first = editAndSave({ status: "shipped", tracking: "PX1" });
+    await editAndSave({ status: "shipped", tracking: "PX123" });
+    failFirst(new Error("token expired"));
+    await first;
+
+    expect(getState().draft).toEqual({ status: "shipped", tracking: "PX123" });
+    expect(getState().persisted).toEqual({ status: "shipped", tracking: "PX123" });
+    expect(getState().error).toBeNull();
+  });
+});

--- a/src/orders/fulfillmentSave.ts
+++ b/src/orders/fulfillmentSave.ts
@@ -1,0 +1,66 @@
+import type { FulfillmentStatus } from "@sznyt/shared";
+
+export const FULFILLMENT_SAVE_ERROR = "Nie udało się zapisać — spróbuj ponownie.";
+
+export type FulfillmentDraft = {
+  status: FulfillmentStatus;
+  tracking: string;
+};
+
+export type FulfillmentSaveState = {
+  /** What the controls currently show. */
+  draft: FulfillmentDraft;
+  /** Last values confirmed by the backend — the revert target. */
+  persisted: FulfillmentDraft;
+  saving: boolean;
+  error: string | null;
+};
+
+export type FulfillmentSaveAction =
+  | { type: "edit"; draft: FulfillmentDraft }
+  | { type: "saveStart" }
+  | { type: "saveSuccess"; saved: FulfillmentDraft }
+  | { type: "saveFailure" };
+
+export function initFulfillmentSave(persisted: FulfillmentDraft): FulfillmentSaveState {
+  return { draft: persisted, persisted, saving: false, error: null };
+}
+
+export function fulfillmentSaveReducer(
+  state: FulfillmentSaveState,
+  action: FulfillmentSaveAction,
+): FulfillmentSaveState {
+  switch (action.type) {
+    case "edit":
+      return { ...state, draft: action.draft };
+    case "saveStart":
+      return { ...state, saving: true };
+    case "saveSuccess":
+      return { ...state, persisted: action.saved, saving: false, error: null };
+    case "saveFailure":
+      return { ...state, draft: state.persisted, saving: false, error: FULFILLMENT_SAVE_ERROR };
+  }
+}
+
+/**
+ * Wraps the PATCH call and dispatches the save lifecycle. Saves can overlap
+ * (the tracking input stays enabled while a save is in flight); only the
+ * newest save's outcome is applied, so a slow stale response can't clobber
+ * the state a later save already confirmed.
+ */
+export function createFulfillmentSaver(
+  patch: (draft: FulfillmentDraft) => Promise<unknown>,
+  dispatch: (action: FulfillmentSaveAction) => void,
+) {
+  let newest = 0;
+  return async function saveFulfillment(draft: FulfillmentDraft): Promise<void> {
+    const seq = ++newest;
+    dispatch({ type: "saveStart" });
+    try {
+      await patch(draft);
+      if (seq === newest) dispatch({ type: "saveSuccess", saved: draft });
+    } catch {
+      if (seq === newest) dispatch({ type: "saveFailure" });
+    }
+  };
+}

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -1,41 +1,52 @@
-import { useState } from "react";
+import { useMemo, useReducer } from "react";
 import { FULFILLMENT_STATUSES, FULFILLMENT_LABELS_SHORT } from "@sznyt/shared";
+import type { FulfillmentStatus } from "@sznyt/shared";
 import type { AdminOrder } from "../../types";
 import { useAuth } from "@clerk/react";
 import Skeleton from "../../components/Skeleton";
 import { apiFetch } from "../../lib/api";
 import { useResource } from "../../hooks/useResource";
 import { formatOrderDate } from "../../orders/formatting";
+import {
+  createFulfillmentSaver,
+  fulfillmentSaveReducer,
+  initFulfillmentSave,
+  type FulfillmentDraft,
+} from "../../orders/fulfillmentSave";
 
 function FulfillmentCell({ order }: { order: AdminOrder }) {
   const { getToken } = useAuth();
-  const [status, setStatus] = useState(order.fulfillmentStatus);
-  const [tracking, setTracking] = useState(order.trackingNumber ?? "");
-  const [saving, setSaving] = useState(false);
+  const [state, dispatch] = useReducer(
+    fulfillmentSaveReducer,
+    {
+      status: order.fulfillmentStatus as FulfillmentStatus,
+      tracking: order.trackingNumber ?? "",
+    },
+    initFulfillmentSave,
+  );
 
-  async function save(newStatus: string, newTracking: string) {
-    setSaving(true);
-    try {
-      await apiFetch(`/orders/${order.id}/fulfillment`, {
-        method: "PATCH",
-        auth: getToken,
-        body: { fulfillmentStatus: newStatus, trackingNumber: newTracking },
-      });
-    } catch {
-      // non-blocking
-    } finally {
-      setSaving(false);
-    }
-  }
+  const save = useMemo(
+    () =>
+      createFulfillmentSaver(function patchFulfillment(draft: FulfillmentDraft) {
+        return apiFetch(`/orders/${order.id}/fulfillment`, {
+          method: "PATCH",
+          auth: getToken,
+          body: { fulfillmentStatus: draft.status, trackingNumber: draft.tracking },
+        });
+      }, dispatch),
+    [order.id, getToken],
+  );
 
   return (
     <div className="flex flex-col gap-1 min-w-45">
       <select
-        value={status}
-        disabled={saving}
+        value={state.draft.status}
+        disabled={state.saving}
         onChange={(e) => {
-          setStatus(e.target.value);
-          save(e.target.value, tracking);
+          // options are rendered from FULFILLMENT_STATUSES, so the cast is safe
+          const draft = { ...state.draft, status: e.target.value as FulfillmentStatus };
+          dispatch({ type: "edit", draft });
+          save(draft);
         }}
         className="border border-borders text-sm px-2 py-1 bg-white focus:outline-none focus:border-near-black"
       >
@@ -46,11 +57,16 @@ function FulfillmentCell({ order }: { order: AdminOrder }) {
       <input
         type="text"
         placeholder="Nr przesyłki"
-        value={tracking}
-        onChange={(e) => setTracking(e.target.value)}
-        onBlur={() => save(status, tracking)}
+        value={state.draft.tracking}
+        onChange={(e) =>
+          dispatch({ type: "edit", draft: { ...state.draft, tracking: e.target.value } })
+        }
+        onBlur={() => save(state.draft)}
         className="border border-borders text-xs px-2 py-1 focus:outline-none focus:border-near-black placeholder:text-gray-400"
       />
+      {state.error && (
+        <p role="alert" className="text-xs text-red-600">{state.error}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `FulfillmentCell` no longer swallows PATCH failures: on error the status select and tracking input revert to the last backend-confirmed values and a red in-row error appears ("Nie udalo sie zapisac - sprobuj ponownie."), clearing on the next successful save
- Save state extracted into a pure reducer + saver (`src/orders/fulfillmentSave.ts`), unit-tested at that seam (6 tests, incl. rejected PATCH -> revert + error)
- Overlapping saves are sequenced so a stale failure can't clobber a newer save's confirmed outcome
- Draft `status` typed as shared `FulfillmentStatus` instead of `string`

## Test plan
- [x] `npx tsc -b`, `npx eslint .`, `npm test` (108 passed)
- [ ] Manual: at 375 px with backend stopped, change status / edit tracking -> revert + in-row error; restart backend, save again -> error clears, value sticks

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)