### PR TITLE
feat: admin order detail page at /admin/zamowienia/:id

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -408,7 +408,9 @@ app.get("/orders/:id", requireAuth(), async (req, res) => {
     if (!order) return res.status(404).json({ error: "Nie znaleziono zamówienia" });
     // Guest orders (userId=null) are only reachable via /orders/by-session/:sessionId —
     // sequential ids must not expose their shipping data to other signed-in users.
-    if (order.userId !== getAuth(req).userId) {
+    // Admins bypass the ownership check: the admin order-detail page reads any
+    // order (guest ones included) through this endpoint.
+    if (order.userId !== getAuth(req).userId && getRole(req) !== "admin") {
       return res.status(403).json({ error: "Forbidden" });
     }
     res.json(order);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import AdminAddProduct from "./pages/admin/AdminAddProduct";
 import AdminEditProduct from "./pages/admin/AdminEditProduct";
 import OrderSuccess from "./pages/OrderSuccess";
 import AdminOrders from "./pages/admin/AdminOrders";
+import AdminOrderDetail from "./pages/admin/AdminOrderDetail";
 import MyOrders from "./pages/MyOrders";
 import OrderDetail from "./pages/OrderDetail";
 import Regulamin from "./pages/Regulamin";
@@ -48,6 +49,7 @@ function App() {
             <Route path="/admin/produkty/nowy" element={<AdminAddProduct />} />
             <Route path="/admin/produkty/:id" element={<AdminEditProduct />} />
             <Route path="/admin/zamowienia" element={<AdminOrders />} />
+            <Route path="/admin/zamowienia/:id" element={<AdminOrderDetail />} />
           </Route>
         </Routes>
       </CartProvider>

--- a/src/orders/FulfillmentControls.tsx
+++ b/src/orders/FulfillmentControls.tsx
@@ -1,0 +1,86 @@
+import { useMemo, useReducer } from "react";
+import { FULFILLMENT_STATUSES, FULFILLMENT_LABELS_SHORT } from "@sznyt/shared";
+import type { FulfillmentStatus } from "@sznyt/shared";
+import { useAuth } from "@clerk/react";
+import { apiFetch } from "../lib/api";
+import {
+  createFulfillmentSaver,
+  fulfillmentSaveReducer,
+  initFulfillmentSave,
+  type FulfillmentDraft,
+} from "./fulfillmentSave";
+
+/**
+ * The status select + tracking input pair used on every admin surface that
+ * fulfills orders (the orders list cell and the order detail page). Saves
+ * through PATCH /orders/:id/fulfillment, which also fires the shipping
+ * confirmation email — the two surfaces share behavior by sharing this
+ * component. Uncontrolled from the parent's perspective: owns its own draft
+ * state seeded from the order's persisted values.
+ */
+function FulfillmentControls({
+  orderId,
+  fulfillmentStatus,
+  trackingNumber,
+}: {
+  orderId: number;
+  fulfillmentStatus: string;
+  trackingNumber: string | null;
+}) {
+  const { getToken } = useAuth();
+  const [state, dispatch] = useReducer(
+    fulfillmentSaveReducer,
+    {
+      status: fulfillmentStatus as FulfillmentStatus,
+      tracking: trackingNumber ?? "",
+    },
+    initFulfillmentSave,
+  );
+
+  const save = useMemo(
+    () =>
+      createFulfillmentSaver(function patchFulfillment(draft: FulfillmentDraft) {
+        return apiFetch(`/orders/${orderId}/fulfillment`, {
+          method: "PATCH",
+          auth: getToken,
+          body: { fulfillmentStatus: draft.status, trackingNumber: draft.tracking },
+        });
+      }, dispatch),
+    [orderId, getToken],
+  );
+
+  return (
+    <div className="flex flex-col gap-1 min-w-45">
+      <select
+        value={state.draft.status}
+        disabled={state.saving}
+        onChange={(e) => {
+          // options are rendered from FULFILLMENT_STATUSES, so the cast is safe
+          const draft = { ...state.draft, status: e.target.value as FulfillmentStatus };
+          dispatch({ type: "edit", draft });
+          save(draft);
+        }}
+        className="border border-borders text-sm px-2 py-1 bg-white focus:outline-none focus:border-near-black"
+      >
+        {FULFILLMENT_STATUSES.map((s) => (
+          <option key={s} value={s}>{FULFILLMENT_LABELS_SHORT[s]}</option>
+        ))}
+      </select>
+      <input
+        type="text"
+        placeholder="Nr przesyłki"
+        value={state.draft.tracking}
+        onChange={(e) =>
+          dispatch({ type: "edit", draft: { ...state.draft, tracking: e.target.value } })
+        }
+        onBlur={() => save(state.draft)}
+        className="border border-borders text-xs px-2 py-1 focus:outline-none focus:border-near-black placeholder:text-gray-400"
+      />
+      {state.error && (
+        <p role="alert" className="text-xs text-red-600">{state.error}</p>
+      )}
+    </div>
+  );
+}
+
+export default FulfillmentControls;

--- a/src/orders/OrderCard.tsx
+++ b/src/orders/OrderCard.tsx
@@ -33,7 +33,7 @@ const FULFILLMENT_CONFIG: Record<string, { label: string; dot: string }> = {
   delivered:  { label: FULFILLMENT_LABELS.delivered,  dot: "bg-green-700" },
 };
 
-const DELETED_PRODUCT_NAME = "Produkt usunięty";
+export const DELETED_PRODUCT_NAME = "Produkt usunięty";
 
 function StatusBadge({ status }: { status: string }) {
   const config = STATUS_CONFIG[status] ?? { label: status, dot: "bg-gray-400" };
@@ -55,7 +55,7 @@ function FulfillmentBadge({ status, labelClassName }: { status: string; labelCla
   );
 }
 
-function ItemThumb({ item, sizeClass }: { item: OrderItem; sizeClass: string }) {
+export function ItemThumb({ item, sizeClass }: { item: OrderItem; sizeClass: string }) {
   if (!item.product?.imageUrl) return <div className={`${sizeClass} bg-borders shrink-0`} />;
   return (
     <div

--- a/src/pages/admin/AdminOrderDetail.tsx
+++ b/src/pages/admin/AdminOrderDetail.tsx
@@ -1,0 +1,158 @@
+import { useParams, Link } from "react-router-dom";
+import {
+  ORDER_STATUS_LABELS,
+  SHIPPING_METHOD_LABELS,
+  PAYMENT_METHOD_LABELS,
+} from "@sznyt/shared";
+import type { AdminOrderPayload, OrderItem } from "../../types";
+import Skeleton from "../../components/Skeleton";
+import { useResource } from "../../hooks/useResource";
+import { formatOrderDate, formatPaczkomatLine } from "../../orders/formatting";
+import FulfillmentControls from "../../orders/FulfillmentControls";
+import { ItemThumb, DELETED_PRODUCT_NAME } from "../../orders/OrderCard";
+
+// Utilitarian admin projection of one order: everything the fulfillment flow
+// needs on a single screen, controls first. The elegant customer rendering
+// lives in orders/OrderCard — this page intentionally doesn't reuse it.
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <p className="text-xs text-gray-500 tracking-widest uppercase mb-2">{children}</p>
+  );
+}
+
+function LineItemRow({ item }: { item: OrderItem }) {
+  return (
+    <div className="flex items-center gap-3 py-3">
+      <ItemThumb item={item} sizeClass="w-12 h-12" />
+      <div className="flex-1 min-w-0">
+        <p className="font-medium truncate">{item.product?.name ?? DELETED_PRODUCT_NAME}</p>
+        <p className="text-xs text-gray-500">
+          {item.quantity} szt. × {item.price} PLN
+        </p>
+      </div>
+      <p className="font-medium whitespace-nowrap">{item.price * item.quantity} PLN</p>
+    </div>
+  );
+}
+
+function AdminOrderDetail() {
+  const { id } = useParams();
+  const { data: order, error: loadFailed } = useResource<AdminOrderPayload>(
+    `/orders/${id}`,
+    { auth: true },
+  );
+
+  if (loadFailed)
+    return <p className="p-4 text-red-600 font-dm-sans text-sm">Nie udało się załadować zamówienia.</p>;
+
+  if (!order)
+    return (
+      <div className="p-4 max-w-2xl font-dm-sans">
+        <Skeleton className="h-5 w-32 mb-6" />
+        <Skeleton className="h-8 w-56 mb-2" />
+        <Skeleton className="h-5 w-72 mb-8" />
+        <Skeleton className="h-24 w-full mb-8" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+
+  const address = order.shippingAddress;
+  const isPaczkomat = order.shippingMethod === "paczkomat";
+
+  return (
+    <div className="p-4 max-w-2xl font-dm-sans text-sm text-near-black">
+      <Link
+        to="/admin/zamowienia"
+        className="text-xs text-gray-500 tracking-widest uppercase hover:text-accent transition-colors mb-6 inline-block"
+      >
+        ← Zamówienia
+      </Link>
+
+      {/* Header */}
+      <h1 className="text-xl font-medium mb-1">Zamówienie #{order.id}</h1>
+      <p className="text-gray-500 mb-1">
+        {formatOrderDate(order.createdAt)} · {ORDER_STATUS_LABELS[order.status] ?? order.status}
+      </p>
+      {order.customerEmail && <p className="text-gray-500 mb-6">{order.customerEmail}</p>}
+
+      {/* Fulfillment controls — the reason this page exists, so they come first */}
+      <div className="border border-borders p-4 mb-8">
+        <SectionLabel>Realizacja</SectionLabel>
+        <div className="max-w-xs">
+          <FulfillmentControls
+            orderId={order.id}
+            fulfillmentStatus={order.fulfillmentStatus}
+            trackingNumber={order.trackingNumber}
+          />
+        </div>
+      </div>
+
+      {/* Line items */}
+      <div className="mb-8">
+        <SectionLabel>Pozycje</SectionLabel>
+        <div className="divide-y divide-borders border-y border-borders">
+          {order.items.map((item) => (
+            <LineItemRow key={item.id} item={item} />
+          ))}
+        </div>
+        <div className="flex justify-between py-3 font-medium">
+          <span>Suma</span>
+          <span>{order.total} PLN</span>
+        </div>
+      </div>
+
+      {/* Shipping + payment */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+        <div>
+          <SectionLabel>Dostawa</SectionLabel>
+          {order.shippingMethod ? (
+            <div className="flex flex-col gap-0.5">
+              <p className="font-medium">
+                {SHIPPING_METHOD_LABELS[order.shippingMethod] ?? order.shippingMethod}
+              </p>
+              {isPaczkomat && address?.code && <p>{formatPaczkomatLine(address)}</p>}
+              {isPaczkomat && address?.name && <p>{address.name}</p>}
+            </div>
+          ) : (
+            <p className="text-gray-500">Brak danych</p>
+          )}
+        </div>
+
+        <div>
+          <SectionLabel>Płatność</SectionLabel>
+          <p>
+            {order.paymentMethod
+              ? PAYMENT_METHOD_LABELS[order.paymentMethod] ?? order.paymentMethod
+              : "Brak danych"}
+          </p>
+        </div>
+
+        <div className="sm:col-span-2">
+          <SectionLabel>Dane odbiorcy</SectionLabel>
+          {address ? (
+            <div className="flex flex-col gap-0.5">
+              {address.firstName && <p>{address.firstName} {address.lastName}</p>}
+              {address.street && <p>{address.street}</p>}
+              {address.postalCode && <p>{address.postalCode} {address.city}</p>}
+              {address.phone && <p>{address.phone}</p>}
+              {address.email && <p>{address.email}</p>}
+            </div>
+          ) : (
+            <p className="text-gray-500">Brak danych</p>
+          )}
+        </div>
+      </div>
+
+      {/* Customer note */}
+      {order.note && (
+        <div className="mb-8">
+          <SectionLabel>Uwagi do zamówienia</SectionLabel>
+          <p className="text-accent font-medium">{order.note}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AdminOrderDetail;

--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -1,75 +1,9 @@
-import { useMemo, useReducer } from "react";
-import { FULFILLMENT_STATUSES, FULFILLMENT_LABELS_SHORT } from "@sznyt/shared";
-import type { FulfillmentStatus } from "@sznyt/shared";
+import { Link } from "react-router-dom";
 import type { AdminOrder } from "../../types";
-import { useAuth } from "@clerk/react";
 import Skeleton from "../../components/Skeleton";
-import { apiFetch } from "../../lib/api";
 import { useResource } from "../../hooks/useResource";
 import { formatOrderDate } from "../../orders/formatting";
-import {
-  createFulfillmentSaver,
-  fulfillmentSaveReducer,
-  initFulfillmentSave,
-  type FulfillmentDraft,
-} from "../../orders/fulfillmentSave";
-
-function FulfillmentCell({ order }: { order: AdminOrder }) {
-  const { getToken } = useAuth();
-  const [state, dispatch] = useReducer(
-    fulfillmentSaveReducer,
-    {
-      status: order.fulfillmentStatus as FulfillmentStatus,
-      tracking: order.trackingNumber ?? "",
-    },
-    initFulfillmentSave,
-  );
-
-  const save = useMemo(
-    () =>
-      createFulfillmentSaver(function patchFulfillment(draft: FulfillmentDraft) {
-        return apiFetch(`/orders/${order.id}/fulfillment`, {
-          method: "PATCH",
-          auth: getToken,
-          body: { fulfillmentStatus: draft.status, trackingNumber: draft.tracking },
-        });
-      }, dispatch),
-    [order.id, getToken],
-  );
-
-  return (
-    <div className="flex flex-col gap-1 min-w-45">
-      <select
-        value={state.draft.status}
-        disabled={state.saving}
-        onChange={(e) => {
-          // options are rendered from FULFILLMENT_STATUSES, so the cast is safe
-          const draft = { ...state.draft, status: e.target.value as FulfillmentStatus };
-          dispatch({ type: "edit", draft });
-          save(draft);
-        }}
-        className="border border-borders text-sm px-2 py-1 bg-white focus:outline-none focus:border-near-black"
-      >
-        {FULFILLMENT_STATUSES.map((s) => (
-          <option key={s} value={s}>{FULFILLMENT_LABELS_SHORT[s]}</option>
-        ))}
-      </select>
-      <input
-        type="text"
-        placeholder="Nr przesyłki"
-        value={state.draft.tracking}
-        onChange={(e) =>
-          dispatch({ type: "edit", draft: { ...state.draft, tracking: e.target.value } })
-        }
-        onBlur={() => save(state.draft)}
-        className="border border-borders text-xs px-2 py-1 focus:outline-none focus:border-near-black placeholder:text-gray-400"
-      />
-      {state.error && (
-        <p role="alert" className="text-xs text-red-600">{state.error}</p>
-      )}
-    </div>
-  );
-}
+import FulfillmentControls from "../../orders/FulfillmentControls";
 
 function AdminOrders() {
   const { data: orders, error: loadFailed } = useResource<AdminOrder[]>("/orders", { auth: true });
@@ -119,11 +53,22 @@ function AdminOrders() {
         <tbody>
           {orders.map((order) => (
             <tr className="border-b border-borders align-top" key={order.id}>
-              <td className="p-3 font-medium">#{order.id}</td>
+              <td className="p-3 font-medium">
+                <Link
+                  to={`/admin/zamowienia/${order.id}`}
+                  className="underline underline-offset-2 hover:text-accent transition-colors"
+                >
+                  #{order.id}
+                </Link>
+              </td>
               <td className="p-3 text-xs">{order.customerEmail ?? "—"}</td>
               <td className="p-3">{order.status}</td>
               <td className="p-3">
-                <FulfillmentCell order={order} />
+                <FulfillmentControls
+                  orderId={order.id}
+                  fulfillmentStatus={order.fulfillmentStatus}
+                  trackingNumber={order.trackingNumber}
+                />
               </td>
               <td className="p-3">{order.total} PLN</td>
               <td className="p-3">{order.shippingMethod ?? "—"}</td>

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,12 @@ export type Order = {
   items: OrderItem[];
 };
 
+// The admin detail page reads the same /orders/:id payload as the customer
+// page; the backend row additionally carries the customer's email.
+export type AdminOrderPayload = Order & {
+  customerEmail: string | null;
+};
+
 export type AdminOrder = {
   id: number;
   stripeSessionId: string;


### PR DESCRIPTION
## Summary
- New admin-gated route `/admin/zamowienia/:id`: line items with thumbnails, full shipping address, payment method, customer email + note, fulfillment controls on top (utilitarian layout confirmed with Adrian: single column at 375, two-column info grid from 768)
- Fulfillment controls extracted from the orders-list cell into shared `src/orders/FulfillmentControls.tsx` — both surfaces share one save path (PATCH + shipping email + revert-on-error from #66); list keeps its inline controls, rows link to the detail page via the order id
- Backend: admins bypass the ownership check on `GET /orders/:id` (covers guest orders, userId=null)

## Test plan
- [x] Typecheck + full vitest suite (108/108)
- [x] Driven in the browser: list → detail, status change PATCH 200 on a guest order, revert confirmed in DB
- [x] Unauthenticated API access still blocked; missing order shows error state
- [x] Checked at 375 / 768 / 1440 — no horizontal overflow
- [x] Layout approved by Adrian

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
