### PR TITLE
fix: merge cart lines by product id instead of appending duplicates

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: verify
+description: How to launch and drive this app for runtime verification — dev stack, browser driving, cart/localStorage gotchas.
+---
+
+# Verifying sznyt_design at runtime
+
+## Launch
+
+```bash
+npm run dev   # concurrently: vite frontend :5173 + backend :3000 (needs local Postgres up)
+```
+
+Readiness probes:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5173/   # 200
+curl -s http://localhost:3000/products                          # JSON product list
+```
+
+Products come from the backend — seeded DB required (`npx tsx seed.js` from `backend/` if empty).
+
+## Drive
+
+Use the chrome-devtools MCP tools. Open pages with `isolatedContext: "<task-name>"` so cookies/localStorage don't bleed between verification tasks.
+
+Useful routes: `/sklep` (list), `/sklep/:id` (product), `/koszyk` (cart), `/kasa` (checkout), `/admin` (needs Clerk admin login — hard headless; verify around it).
+
+## Gotchas
+
+- Cart persistence is gated on cookie consent: click "Akceptuj" on the banner first, else `localStorage.cart` is never written.
+- Cart state lives in `localStorage.cart` — inspect/seed it directly with `evaluate_script` for load-time scenarios, then reload.
+- Same-tick UI races (double-click bugs) reproduce via `evaluate_script` calling `btn.click()` twice in one function — MCP click roundtrips are too slow to race React renders.
+- Stripe flows need `stripe listen --forward-to localhost:3000/webhook` and the account matching `.env` keys (see memory: account mismatch → webhook 500).

--- a/src/cart/cartItems.test.ts
+++ b/src/cart/cartItems.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { addToCart, mergeDuplicateItems } from "./cartItems";
+import type { CartItem } from "../types";
+
+function frame(overrides: Partial<CartItem> = {}): CartItem {
+  return {
+    id: 2,
+    name: "Ramka Corner Cut",
+    price: 249,
+    imageUrl: "/img/corner-cut.jpg",
+    quantity: 1,
+    stock: 5,
+    ...overrides,
+  };
+}
+
+describe("addToCart", () => {
+  it("increments quantity of an existing line instead of appending a duplicate", () => {
+    const cart = [frame({ quantity: 1 })];
+
+    const result = addToCart(cart, {
+      id: 2,
+      name: "Ramka Corner Cut",
+      price: 249,
+      imageUrl: "/img/corner-cut.jpg",
+      stock: 5,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].quantity).toBe(2);
+  });
+
+  it("appends a new line with quantity 1 for a product not in the cart", () => {
+    const cart = [frame({ id: 1, name: "Ramka Oak" })];
+
+    const result = addToCart(cart, {
+      id: 2,
+      name: "Ramka Corner Cut",
+      price: 249,
+      imageUrl: "/img/corner-cut.jpg",
+      stock: 5,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[1]).toEqual(frame({ quantity: 1 }));
+  });
+
+  it("does not increment past available stock", () => {
+    const cart = [frame({ quantity: 5, stock: 5 })];
+
+    const result = addToCart(cart, {
+      id: 2,
+      name: "Ramka Corner Cut",
+      price: 249,
+      imageUrl: "/img/corner-cut.jpg",
+      stock: 5,
+    });
+
+    expect(result).toEqual(cart);
+  });
+
+  it("does not add a product with zero stock", () => {
+    const result = addToCart([], {
+      id: 2,
+      name: "Ramka Corner Cut",
+      price: 249,
+      imageUrl: "/img/corner-cut.jpg",
+      stock: 0,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("mergeDuplicateItems", () => {
+  it("collapses duplicate lines of the same product into one, summing quantities", () => {
+    const stored = [
+      frame({ quantity: 1 }),
+      frame({ id: 1, name: "Ramka Oak", quantity: 1 }),
+      frame({ quantity: 1 }),
+    ];
+
+    const result = mergeDuplicateItems(stored);
+
+    expect(result).toEqual([
+      frame({ quantity: 2 }),
+      frame({ id: 1, name: "Ramka Oak", quantity: 1 }),
+    ]);
+  });
+
+  it("caps the merged quantity at available stock", () => {
+    const stored = [
+      frame({ quantity: 3, stock: 5 }),
+      frame({ quantity: 3, stock: 5 }),
+    ];
+
+    const result = mergeDuplicateItems(stored);
+
+    expect(result).toEqual([frame({ quantity: 5, stock: 5 })]);
+  });
+});

--- a/src/cart/cartItems.test.ts
+++ b/src/cart/cartItems.test.ts
@@ -14,17 +14,19 @@ function frame(overrides: Partial<CartItem> = {}): CartItem {
   };
 }
 
+function product(
+  overrides: Partial<Omit<CartItem, "quantity">> = {},
+): Omit<CartItem, "quantity"> {
+  const item: Partial<CartItem> = frame(overrides);
+  delete item.quantity;
+  return item as Omit<CartItem, "quantity">;
+}
+
 describe("addToCart", () => {
   it("increments quantity of an existing line instead of appending a duplicate", () => {
     const cart = [frame({ quantity: 1 })];
 
-    const result = addToCart(cart, {
-      id: 2,
-      name: "Ramka Corner Cut",
-      price: 249,
-      imageUrl: "/img/corner-cut.jpg",
-      stock: 5,
-    });
+    const result = addToCart(cart, product());
 
     expect(result).toHaveLength(1);
     expect(result[0].quantity).toBe(2);
@@ -33,42 +35,28 @@ describe("addToCart", () => {
   it("appends a new line with quantity 1 for a product not in the cart", () => {
     const cart = [frame({ id: 1, name: "Ramka Oak" })];
 
-    const result = addToCart(cart, {
-      id: 2,
-      name: "Ramka Corner Cut",
-      price: 249,
-      imageUrl: "/img/corner-cut.jpg",
-      stock: 5,
-    });
+    const result = addToCart(cart, product());
 
     expect(result).toHaveLength(2);
     expect(result[1]).toEqual(frame({ quantity: 1 }));
   });
 
-  it("does not increment past available stock", () => {
+  it("does not increment past available stock — returns the input array untouched", () => {
     const cart = [frame({ quantity: 5, stock: 5 })];
 
-    const result = addToCart(cart, {
-      id: 2,
-      name: "Ramka Corner Cut",
-      price: 249,
-      imageUrl: "/img/corner-cut.jpg",
-      stock: 5,
-    });
+    const result = addToCart(cart, product());
 
-    expect(result).toEqual(cart);
+    // same reference on no-op is contract: CartProvider uses it to decide
+    // whether the add succeeded
+    expect(result).toBe(cart);
   });
 
-  it("does not add a product with zero stock", () => {
-    const result = addToCart([], {
-      id: 2,
-      name: "Ramka Corner Cut",
-      price: 249,
-      imageUrl: "/img/corner-cut.jpg",
-      stock: 0,
-    });
+  it("does not add a product with zero stock — returns the input array untouched", () => {
+    const cart: CartItem[] = [];
 
-    expect(result).toEqual([]);
+    const result = addToCart(cart, product({ stock: 0 }));
+
+    expect(result).toBe(cart);
   });
 });
 

--- a/src/cart/cartItems.ts
+++ b/src/cart/cartItems.ts
@@ -1,0 +1,29 @@
+import type { CartItem } from "../types";
+
+export function addToCart(
+  items: CartItem[],
+  newItem: Omit<CartItem, "quantity">,
+): CartItem[] {
+  const existing = items.find((i) => i.id === newItem.id);
+  if (existing) {
+    if (existing.quantity >= existing.stock) return items;
+    return items.map((i) =>
+      i.id === newItem.id ? { ...i, quantity: i.quantity + 1 } : i,
+    );
+  }
+  if (newItem.stock === 0) return items;
+  return [...items, { ...newItem, quantity: 1 }];
+}
+
+export function mergeDuplicateItems(items: CartItem[]): CartItem[] {
+  const merged: CartItem[] = [];
+  for (const item of items) {
+    const existing = merged.find((i) => i.id === item.id);
+    if (existing) {
+      existing.quantity = Math.min(existing.quantity + item.quantity, existing.stock);
+    } else {
+      merged.push({ ...item });
+    }
+  }
+  return merged;
+}

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { CartItem } from "../types";
 import { CartContext } from "./cart-context";
+import { addToCart, mergeDuplicateItems } from "../cart/cartItems";
 import { useCookieConsent } from "../hooks/useCookieConsent";
 
 export function CartProvider({ children }: { children: React.ReactNode }) {
@@ -9,7 +10,8 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     if (localStorage.getItem("cookie_consent") === "accepted") {
       try {
         const stored = localStorage.getItem("cart");
-        return stored ? JSON.parse(stored) : [];
+        // merge, not just parse — carts saved before #70 may hold duplicate lines
+        return stored ? mergeDuplicateItems(JSON.parse(stored)) : [];
       } catch {
         return [];
       }
@@ -29,17 +31,9 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     const existing = items.find((i) => i.id === newItem.id);
     if (existing && existing.quantity >= existing.stock) return false;
     if (newItem.stock === 0) return false;
-    setItems((prev) => {
-      if (existing) {
-        return prev.map((i) =>
-          i.id === newItem.id && i.quantity < i.stock
-            ? { ...i, quantity: i.quantity + 1 }
-            : i,
-        );
-      }
-      if (newItem.stock === 0) return prev;
-      return [...prev, { ...newItem, quantity: 1 }];
-    });
+    // merge decision must run against prev, not the render closure — two rapid
+    // clicks before a re-render would otherwise both append a fresh line (#70)
+    setItems((prev) => addToCart(prev, newItem));
     return true;
   }
 

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -28,13 +28,12 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
   }, [items, consent]);
 
   function addItem(newItem: Omit<CartItem, "quantity">) {
-    const existing = items.find((i) => i.id === newItem.id);
-    if (existing && existing.quantity >= existing.stock) return false;
-    if (newItem.stock === 0) return false;
     // merge decision must run against prev, not the render closure — two rapid
-    // clicks before a re-render would otherwise both append a fresh line (#70)
+    // clicks before a re-render would otherwise both append a fresh line (#70).
+    // The returned boolean drives toast feedback only; it reflects render-time
+    // state (addToCart returns the same reference when nothing would change).
     setItems((prev) => addToCart(prev, newItem));
-    return true;
+    return addToCart(items, newItem) !== items;
   }
 
   function removeItem(id: number) {


### PR DESCRIPTION
## Summary
- Root cause was not "always appends": `addItem` already merged by id, but decided merge-vs-append from the render closure's `items`, so two clicks landing before a re-render both appended a fresh line. The merge now runs against `prev` inside `setItems` via a pure `addToCart` (`src/cart/cartItems.ts`).
- Carts persisted with duplicate lines (pre-fix) are repaired on load with `mergeDuplicateItems` in the provider's lazy initializer; the repaired cart is written back merged on the next persist. Merged quantity caps at stock.
- `addToCart` returns the input reference on a no-op — the provider derives its toast boolean from that instead of duplicating the stock guards.
- Checkout note from the issue: `buildCheckoutRequest` maps cart lines 1:1 to `{id, quantity}`, so with carts now merged on add *and* on load, duplicated Stripe line items can't originate from the UI.
- Rides along: `.claude/skills/verify/SKILL.md` — runtime-verification recipe captured while verifying this fix.

## Test plan
- [x] 6 unit tests for `addToCart` / `mergeDuplicateItems` (114 total pass), tsc + eslint clean
- [x] Verified in the running app: same-tick double-click on `/sklep/2` → one line qty 2 in `/koszyk`; seeded 3 duplicate localStorage lines → merged to one qty 3 on reload; 10 rapid clicks → capped at stock 7, button disables

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)