### PR TITLE
feat: highlight customer note in admin new-order email

### DIFF
--- a/backend/emails/layout.ts
+++ b/backend/emails/layout.ts
@@ -8,6 +8,7 @@ const COLORS = {
   accent: "#B8965A",
   secondaryText: "#6B6560",
   borders: "#E5E2DD",
+  calloutBackground: "#F6F1E7",
 };
 
 const SERIF = `'Cormorant Garamond', Georgia, serif`;
@@ -60,6 +61,15 @@ export function wrapHtml({ title, bodyHtml }: { title: string; bodyHtml: string 
 /** Small labelled key/value row used across templates. */
 export function metaRowHtml(label: string, value: string): string {
   return `<p style="margin:0 0 4px;"><span style="color:${COLORS.secondaryText};">${escapeHtml(label)}:</span> ${escapeHtml(value)}</p>`;
+}
+
+/**
+ * Highlighted callout for content that must not be skimmed past (e.g. customer
+ * notes with gate codes). Table-based with inline styles — the only markup
+ * email clients reliably render.
+ */
+export function calloutHtml(label: string, value: string): string {
+  return `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 16px;"><tr><td style="background:${COLORS.calloutBackground};border-left:3px solid ${COLORS.accent};padding:12px 16px;"><span style="font-family:${SANS};font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:${COLORS.accent};">${escapeHtml(label)}</span><br><span style="font-size:15px;color:${COLORS.nearBlack};">${textBlockToHtml(value)}</span></td></tr></table>`;
 }
 
 /** Accent-colored section heading inside the card. */

--- a/backend/emails/renderAdminNewOrder.test.ts
+++ b/backend/emails/renderAdminNewOrder.test.ts
@@ -21,6 +21,8 @@ const sampleOrder: OrderEmailData = {
   note: null,
 };
 
+const orderWithNote: OrderEmailData = { ...sampleOrder, note: "Kod do bramy: 1234" };
+
 describe("renderAdminNewOrder", () => {
   const { subject, html, text } = renderAdminNewOrder(sampleOrder);
 
@@ -53,10 +55,7 @@ describe("renderAdminNewOrder", () => {
   );
 
   it.each(["html", "text"] as const)("shows the customer note in %s", (channel) => {
-    const rendered = renderAdminNewOrder({
-      ...sampleOrder,
-      note: "Kod do bramy: 1234",
-    });
+    const rendered = renderAdminNewOrder(orderWithNote);
     const output = channel === "html" ? rendered.html : rendered.text;
     expect(output).toContain("Kod do bramy: 1234");
   });
@@ -64,10 +63,7 @@ describe("renderAdminNewOrder", () => {
   it.each(["html", "text"] as const)(
     "shows the note prominently in %s — before the order details",
     (channel) => {
-      const rendered = renderAdminNewOrder({
-        ...sampleOrder,
-        note: "Kod do bramy: 1234",
-      });
+      const rendered = renderAdminNewOrder(orderWithNote);
       const output = channel === "html" ? rendered.html : rendered.text;
       expect(output.indexOf("Kod do bramy: 1234")).toBeLessThan(
         output.indexOf("Ramka Orzechowa 21×30"),
@@ -75,8 +71,35 @@ describe("renderAdminNewOrder", () => {
     },
   );
 
+  it("renders the note as a highlighted callout cell in html", () => {
+    const rendered = renderAdminNewOrder(orderWithNote);
+    // Match the <td> that actually contains the note, capturing its style attr.
+    const callout = rendered.html.match(
+      /<td style="([^"]*)">(?:(?!<\/td>)[\s\S])*Kod do bramy: 1234/,
+    );
+    expect(callout).not.toBeNull();
+    expect(callout![1]).toContain("background:#F6F1E7");
+    expect(callout![1]).toContain("border-left:3px solid");
+  });
+
+  it("preserves note line breaks in the html callout", () => {
+    const rendered = renderAdminNewOrder({
+      ...sampleOrder,
+      note: "Kod do bramy: 1234\nZostawić u sąsiada",
+    });
+    expect(rendered.html).toContain("Kod do bramy: 1234<br>Zostawić u sąsiada");
+  });
+
+  it("emphasizes the note with delimiter lines in text", () => {
+    const rendered = renderAdminNewOrder(orderWithNote);
+    expect(rendered.text).toContain("=== UWAGI KLIENTA ===");
+    expect(rendered.text).toContain("Kod do bramy: 1234");
+  });
+
   it("omits the note section when the order has none", () => {
     expect(html).not.toContain("Uwagi do zamówienia");
     expect(text).not.toContain("Uwagi do zamówienia");
+    expect(html).not.toContain("Uwagi klienta");
+    expect(text).not.toContain("UWAGI KLIENTA");
   });
 });

--- a/backend/emails/renderAdminNewOrder.ts
+++ b/backend/emails/renderAdminNewOrder.ts
@@ -1,6 +1,8 @@
-import { formatPln, metaRowHtml, wrapHtml } from "./layout.ts";
+import { calloutHtml, formatPln, metaRowHtml, wrapHtml } from "./layout.ts";
 import { orderDetailsHtml, orderDetailsText } from "./orderSummary.ts";
 import type { OrderEmailData, RenderedEmail } from "./types.ts";
+
+const NOTE_HEADER = "=== UWAGI KLIENTA ===";
 
 /** Paid-order alert for the shop owners (recipient: CONTACT_RECIPIENT). */
 export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
@@ -12,7 +14,7 @@ export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
     title: `Nowe zamówienie #${data.orderId}`,
     bodyHtml: `
       ${metaRowHtml("Klient", data.customerEmail ?? "—")}
-      ${data.note ? metaRowHtml("Uwagi klienta", data.note) : ""}
+      ${data.note ? calloutHtml("Uwagi klienta", data.note) : ""}
       ${orderDetailsHtml(data, { includeNote: false })}
       <p style="margin:24px 0 0;">Zamówienie czeka na realizację w panelu administracyjnym.</p>
     `,
@@ -23,7 +25,7 @@ export function renderAdminNewOrder(data: OrderEmailData): RenderedEmail {
     "",
     `Numer zamówienia: #${data.orderId}`,
     `Klient: ${data.customerEmail ?? "—"}`,
-    ...(data.note ? [`Uwagi klienta: ${data.note}`] : []),
+    ...(data.note ? ["", NOTE_HEADER, data.note, "=".repeat(NOTE_HEADER.length)] : []),
     "",
     orderDetailsText(data, { includeNote: false }),
     "",


### PR DESCRIPTION
## Summary
- Customer note ("Uwagi klienta") in the admin new-order email now renders as a highlighted callout: email-safe table cell with tinted background and accent left border, note text at full size
- Plain-text variant gets delimiter-line emphasis (=== UWAGI KLIENTA ===)
- Multi-line notes now preserve line breaks in HTML
- Note stays at the top, above order details; customer confirmation unchanged

## Test plan
- [x] 5 note-specific tests: callout styling, prominence ordering, line-break preservation, text emphasis, omitted-when-absent
- [x] Full backend suite 60/60, tsc clean

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)