### PR TITLE
feat: persist checkout draft across navigation (sessionStorage)

### DIFF
--- a/src/checkout/checkoutDraftStorage.test.ts
+++ b/src/checkout/checkoutDraftStorage.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { parseStoredDraft, serializeStoredDraft } from "./checkoutDraftStorage";
+import { validAddress } from "./testFixtures";
+import type { StoredCheckoutDraft } from "./checkoutDraftStorage";
+
+const fullDraft: StoredCheckoutDraft = {
+  shippingMethod: "paczkomat",
+  paczkomatPoint: { code: "KRA01M", name: "Paczkomat KRA01M", city: "Kraków" },
+  address: validAddress,
+  note: "Proszę zostawić u sąsiada",
+};
+
+describe("parseStoredDraft", () => {
+  it("round-trips a full draft through serialize", () => {
+    expect(parseStoredDraft(serializeStoredDraft(fullDraft))).toEqual(fullDraft);
+  });
+
+  it("round-trips a pristine draft (nothing selected yet)", () => {
+    const pristine: StoredCheckoutDraft = {
+      shippingMethod: null,
+      paczkomatPoint: null,
+      address: { firstName: "", lastName: "", email: "", street: "", postalCode: "", city: "", phone: "" },
+      note: "",
+    };
+    expect(parseStoredDraft(serializeStoredDraft(pristine))).toEqual(pristine);
+  });
+
+  it("returns null for absent storage value", () => {
+    expect(parseStoredDraft(null)).toBeNull();
+  });
+
+  it("returns null for corrupt JSON", () => {
+    expect(parseStoredDraft("{not json")).toBeNull();
+  });
+
+  it("returns null for non-object payloads", () => {
+    expect(parseStoredDraft('"just a string"')).toBeNull();
+    expect(parseStoredDraft("[1,2]")).toBeNull();
+    expect(parseStoredDraft("null")).toBeNull();
+  });
+
+  it("rejects an unknown shipping method", () => {
+    const raw = serializeStoredDraft(fullDraft).replace("paczkomat", "pigeon");
+    expect(parseStoredDraft(raw)).toBeNull();
+  });
+
+  it("rejects a paczkomat point without a code", () => {
+    const broken = { ...fullDraft, paczkomatPoint: { name: "Paczkomat" } };
+    expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
+  });
+
+  it("rejects an address with a missing field", () => {
+    const partialAddress: Record<string, string> = { ...validAddress };
+    delete partialAddress.phone;
+    const broken = { ...fullDraft, address: partialAddress };
+    expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
+  });
+
+  it("rejects an address with a non-string field", () => {
+    const broken = { ...fullDraft, address: { ...validAddress, phone: 123456789 } };
+    expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
+  });
+
+  it("rejects a non-string note", () => {
+    const broken = { ...fullDraft, note: 42 };
+    expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
+  });
+
+  it("clamps an over-length note to the shared cap", () => {
+    const broken = { ...fullDraft, note: "x".repeat(500) };
+    const parsed = parseStoredDraft(JSON.stringify(broken));
+    expect(parsed?.note).toHaveLength(300);
+  });
+
+  it("drops a stale point when the stored point city is a non-string", () => {
+    const broken = { ...fullDraft, paczkomatPoint: { code: "KRA01M", name: "P", city: 7 } };
+    expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
+  });
+
+  it("accepts a point without the optional city", () => {
+    const draft = { ...fullDraft, paczkomatPoint: { code: "KRA01M", name: "Paczkomat KRA01M" } };
+    expect(parseStoredDraft(JSON.stringify(draft))).toEqual(draft);
+  });
+});

--- a/src/checkout/checkoutDraftStorage.test.ts
+++ b/src/checkout/checkoutDraftStorage.test.ts
@@ -72,7 +72,7 @@ describe("parseStoredDraft", () => {
     expect(parsed?.note).toHaveLength(300);
   });
 
-  it("drops a stale point when the stored point city is a non-string", () => {
+  it("rejects the draft when the stored point city is a non-string", () => {
     const broken = { ...fullDraft, paczkomatPoint: { code: "KRA01M", name: "P", city: 7 } };
     expect(parseStoredDraft(JSON.stringify(broken))).toBeNull();
   });

--- a/src/checkout/checkoutDraftStorage.ts
+++ b/src/checkout/checkoutDraftStorage.ts
@@ -1,0 +1,111 @@
+import { isShippingMethod, ORDER_NOTE_MAX_LENGTH } from "@sznyt/shared";
+import type { ShippingMethod } from "@sznyt/shared";
+import type { CourierAddress, PaczkomatPoint } from "./types";
+
+/**
+ * The checkout draft fields worth surviving navigation (#74). UI state
+ * (fieldErrors, loading, error) and cart items are deliberately absent —
+ * items already persist via CartContext.
+ */
+export type StoredCheckoutDraft = {
+  shippingMethod: ShippingMethod | null;
+  paczkomatPoint: PaczkomatPoint | null;
+  address: CourierAddress;
+  note: string;
+};
+
+const STORAGE_KEY = "checkout_draft";
+
+const ADDRESS_KEYS: (keyof CourierAddress)[] = [
+  "firstName", "lastName", "street", "postalCode", "city", "phone", "email",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAddress(value: unknown): CourierAddress | null {
+  if (!isRecord(value)) return null;
+  const address = {} as CourierAddress;
+  for (const key of ADDRESS_KEYS) {
+    const field = value[key];
+    if (typeof field !== "string") return null;
+    address[key] = field;
+  }
+  return address;
+}
+
+function parsePoint(value: unknown): PaczkomatPoint | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.code !== "string" || typeof value.name !== "string") return null;
+  if (value.city !== undefined && typeof value.city !== "string") return null;
+  return value.city === undefined
+    ? { code: value.code, name: value.name }
+    : { code: value.code, name: value.name, city: value.city };
+}
+
+/**
+ * Whole-draft-or-nothing: a payload that fails any field check is discarded
+ * entirely rather than partially restored — a half-restored form is more
+ * confusing than an empty one, and the customer can always retype.
+ */
+export function parseStoredDraft(raw: string | null): StoredCheckoutDraft | null {
+  if (raw === null) return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(payload)) return null;
+
+  const shippingMethod =
+    payload.shippingMethod === null
+      ? null
+      : typeof payload.shippingMethod === "string" && isShippingMethod(payload.shippingMethod)
+        ? payload.shippingMethod
+        : undefined;
+  if (shippingMethod === undefined) return null;
+
+  const paczkomatPoint = payload.paczkomatPoint === null ? null : parsePoint(payload.paczkomatPoint);
+  if (payload.paczkomatPoint !== null && paczkomatPoint === null) return null;
+
+  const address = parseAddress(payload.address);
+  if (address === null) return null;
+
+  if (typeof payload.note !== "string") return null;
+  const note = payload.note.slice(0, ORDER_NOTE_MAX_LENGTH);
+
+  return { shippingMethod, paczkomatPoint, address, note };
+}
+
+export function serializeStoredDraft(draft: StoredCheckoutDraft): string {
+  return JSON.stringify(draft);
+}
+
+// sessionStorage over localStorage: the draft is PII (name, address, phone),
+// so it should die with the tab, not persist across visits (#74).
+
+export function loadCheckoutDraft(): StoredCheckoutDraft | null {
+  try {
+    return parseStoredDraft(sessionStorage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function saveCheckoutDraft(draft: StoredCheckoutDraft): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, serializeStoredDraft(draft));
+  } catch {
+    // storage unavailable (privacy mode, quota) — persistence is best-effort
+  }
+}
+
+export function clearCheckoutDraft(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // storage unavailable — nothing to clear
+  }
+}

--- a/src/checkout/checkoutDraftStorage.ts
+++ b/src/checkout/checkoutDraftStorage.ts
@@ -16,9 +16,12 @@ export type StoredCheckoutDraft = {
 
 const STORAGE_KEY = "checkout_draft";
 
-const ADDRESS_KEYS: (keyof CourierAddress)[] = [
-  "firstName", "lastName", "street", "postalCode", "city", "phone", "email",
-];
+// Record<keyof, true> so adding a CourierAddress field breaks compilation
+// here — a key missing from this list would silently pass parsing half-empty.
+const ADDRESS_FIELDS: Record<keyof CourierAddress, true> = {
+  firstName: true, lastName: true, street: true, postalCode: true, city: true, phone: true, email: true,
+};
+const ADDRESS_KEYS = Object.keys(ADDRESS_FIELDS) as (keyof CourierAddress)[];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -59,13 +62,13 @@ export function parseStoredDraft(raw: string | null): StoredCheckoutDraft | null
   }
   if (!isRecord(payload)) return null;
 
-  const shippingMethod =
-    payload.shippingMethod === null
-      ? null
-      : typeof payload.shippingMethod === "string" && isShippingMethod(payload.shippingMethod)
-        ? payload.shippingMethod
-        : undefined;
-  if (shippingMethod === undefined) return null;
+  let shippingMethod: ShippingMethod | null = null;
+  if (payload.shippingMethod !== null) {
+    if (typeof payload.shippingMethod !== "string" || !isShippingMethod(payload.shippingMethod)) {
+      return null;
+    }
+    shippingMethod = payload.shippingMethod;
+  }
 
   const paczkomatPoint = payload.paczkomatPoint === null ? null : parsePoint(payload.paczkomatPoint);
   if (payload.paczkomatPoint !== null && paczkomatPoint === null) return null;

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -3,6 +3,7 @@ export { buildShippingAddress } from "./buildShippingAddress";
 export { checkoutTotals } from "./checkoutTotals";
 export { buildCheckoutRequest } from "./buildCheckoutRequest";
 export { useCheckout } from "./useCheckout";
+export { clearCheckoutDraft } from "./checkoutDraftStorage";
 export { default as PaczkomatPicker } from "./PaczkomatPicker";
 export type { CheckoutDraft, CheckoutMissing, CheckoutFieldErrors, CourierAddress, PaczkomatPoint } from "./types";
 export type { CheckoutValidation } from "./validateCheckoutDraft";

--- a/src/checkout/useCheckout.ts
+++ b/src/checkout/useCheckout.ts
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { ShippingMethod } from "@sznyt/shared";
 import { apiFetch } from "../lib/api";
+import { useCookieConsent } from "../hooks/useCookieConsent";
 import { validateCheckoutDraft } from "./validateCheckoutDraft";
 import { buildCheckoutRequest } from "./buildCheckoutRequest";
+import { loadCheckoutDraft, saveCheckoutDraft, clearCheckoutDraft } from "./checkoutDraftStorage";
 import type { CheckoutDraft, CheckoutFieldErrors, CourierAddress, PaczkomatPoint } from "./types";
 import type { CartItem } from "../types";
 
@@ -18,14 +20,32 @@ const EMPTY_ADDRESS: CourierAddress = {
  * Stripe redirect is this hook's only browser dependency.
  */
 export function useCheckout(items: CartItem[], userId: string | null | undefined) {
-  const [shippingMethod, setShippingMethod] = useState<ShippingMethod | null>(null);
-  const [paczkomatPoint, setPaczkomatPoint] = useState<PaczkomatPoint | null>(null);
+  const { consent } = useCookieConsent();
+  // Same lazy-init consent gate as CartContext: the consent context may not
+  // have settled yet on first render, so read the persisted flag directly.
+  const [restored] = useState(() =>
+    localStorage.getItem("cookie_consent") === "accepted" ? loadCheckoutDraft() : null,
+  );
+  const [shippingMethod, setShippingMethod] = useState<ShippingMethod | null>(
+    restored?.shippingMethod ?? null,
+  );
+  const [paczkomatPoint, setPaczkomatPoint] = useState<PaczkomatPoint | null>(
+    restored?.paczkomatPoint ?? null,
+  );
   const [paczkomatOpenRequested, setPaczkomatOpenRequested] = useState(false);
-  const [address, setAddress] = useState<CourierAddress>(EMPTY_ADDRESS);
-  const [note, setNote] = useState("");
+  const [address, setAddress] = useState<CourierAddress>(restored?.address ?? EMPTY_ADDRESS);
+  const [note, setNote] = useState(restored?.note ?? "");
   const [fieldErrors, setFieldErrors] = useState<CheckoutFieldErrors>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (consent === "accepted") {
+      saveCheckoutDraft({ shippingMethod, paczkomatPoint, address, note });
+    } else {
+      clearCheckoutDraft();
+    }
+  }, [consent, shippingMethod, paczkomatPoint, address, note]);
 
   const draft: CheckoutDraft = { items, shippingMethod, paczkomatPoint, address };
   const isComplete = validateCheckoutDraft(draft).missing.length === 0;

--- a/src/checkout/useCheckout.ts
+++ b/src/checkout/useCheckout.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { ShippingMethod } from "@sznyt/shared";
 import { apiFetch } from "../lib/api";
 import { useCookieConsent } from "../hooks/useCookieConsent";
+import { hasStoredConsent } from "../context/cookie-consent-context";
 import { validateCheckoutDraft } from "./validateCheckoutDraft";
 import { buildCheckoutRequest } from "./buildCheckoutRequest";
 import { loadCheckoutDraft, saveCheckoutDraft, clearCheckoutDraft } from "./checkoutDraftStorage";
@@ -21,11 +22,7 @@ const EMPTY_ADDRESS: CourierAddress = {
  */
 export function useCheckout(items: CartItem[], userId: string | null | undefined) {
   const { consent } = useCookieConsent();
-  // Same lazy-init consent gate as CartContext: the consent context may not
-  // have settled yet on first render, so read the persisted flag directly.
-  const [restored] = useState(() =>
-    localStorage.getItem("cookie_consent") === "accepted" ? loadCheckoutDraft() : null,
-  );
+  const [restored] = useState(() => (hasStoredConsent() ? loadCheckoutDraft() : null));
   const [shippingMethod, setShippingMethod] = useState<ShippingMethod | null>(
     restored?.shippingMethod ?? null,
   );

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -3,11 +3,12 @@ import type { CartItem } from "../types";
 import { CartContext } from "./cart-context";
 import { addToCart, mergeDuplicateItems } from "../cart/cartItems";
 import { useCookieConsent } from "../hooks/useCookieConsent";
+import { hasStoredConsent } from "./cookie-consent-context";
 
 export function CartProvider({ children }: { children: React.ReactNode }) {
   const { consent } = useCookieConsent();
   const [items, setItems] = useState<CartItem[]>(() => {
-    if (localStorage.getItem("cookie_consent") === "accepted") {
+    if (hasStoredConsent()) {
       try {
         const stored = localStorage.getItem("cart");
         // merge, not just parse — carts saved before #70 may hold duplicate lines

--- a/src/context/CookieConsentContext.tsx
+++ b/src/context/CookieConsentContext.tsx
@@ -1,21 +1,21 @@
 import { useState } from "react";
-import { CookieConsentContext, type Consent } from "./cookie-consent-context";
+import { CookieConsentContext, COOKIE_CONSENT_KEY, type Consent } from "./cookie-consent-context";
 
 export function CookieConsentProvider({ children }: { children: React.ReactNode }) {
   const [consent, setConsent] = useState<Consent>(() => {
-    const stored = localStorage.getItem("cookie_consent");
+    const stored = localStorage.getItem(COOKIE_CONSENT_KEY);
     if (stored === "accepted") return "accepted";
     if (stored === "declined") return "declined";
     return null;
   });
 
   function accept() {
-    localStorage.setItem("cookie_consent", "accepted");
+    localStorage.setItem(COOKIE_CONSENT_KEY, "accepted");
     setConsent("accepted");
   }
 
   function decline() {
-    localStorage.setItem("cookie_consent", "declined");
+    localStorage.setItem(COOKIE_CONSENT_KEY, "declined");
     setConsent("declined");
   }
 

--- a/src/context/cookie-consent-context.ts
+++ b/src/context/cookie-consent-context.ts
@@ -2,6 +2,16 @@ import { createContext } from "react";
 
 export type Consent = "accepted" | "declined" | null;
 
+export const COOKIE_CONSENT_KEY = "cookie_consent";
+
+/**
+ * Reads the persisted flag directly — for lazy state initializers that run
+ * before the consent context has settled. Everywhere else, use the context.
+ */
+export function hasStoredConsent(): boolean {
+  return localStorage.getItem(COOKIE_CONSENT_KEY) === "accepted";
+}
+
 export type CookieConsentContextType = {
   consent: Consent;
   accept: () => void;

--- a/src/pages/OrderSuccess.tsx
+++ b/src/pages/OrderSuccess.tsx
@@ -6,6 +6,7 @@ import { Show } from "@clerk/react";
 import { useCart } from "../hooks/useCart";
 import Seo from "../components/Seo";
 import { apiFetch } from "../lib/api";
+import { clearCheckoutDraft } from "../checkout";
 import OrderCard from "../orders/OrderCard";
 
 function OrderSuccess() {
@@ -28,6 +29,8 @@ function OrderSuccess() {
           if (cancelled) return;
           setOrder(data);
           clearCart();
+          // order placed — the draft's PII must not linger in the session (#74)
+          clearCheckoutDraft();
           return;
         } catch {
           // order not recorded yet or network hiccup — fall through to retry

--- a/src/pages/OrderSuccess.tsx
+++ b/src/pages/OrderSuccess.tsx
@@ -18,6 +18,10 @@ function OrderSuccess() {
 
   useEffect(() => {
     if (!sessionId) return;
+    // Arriving here with a session_id means checkout completed — the draft's
+    // PII must not outlive the purchase (#74). Clear before polling: a slow
+    // webhook must not leave the draft behind.
+    clearCheckoutDraft();
     let cancelled = false;
 
     async function load() {
@@ -29,8 +33,6 @@ function OrderSuccess() {
           if (cancelled) return;
           setOrder(data);
           clearCart();
-          // order placed — the draft's PII must not linger in the session (#74)
-          clearCheckoutDraft();
           return;
         } catch {
           // order not recorded yet or network hiccup — fall through to retry


### PR DESCRIPTION
## Summary
- Checkout draft (shipping method, paczkomat point, address, note) now survives navigating away from the cart: persisted to sessionStorage via a new `checkoutDraftStorage` module and restored on mount.
- sessionStorage (not localStorage) because the draft is PII — it dies with the tab.
- Writes are consent-gated with the same pattern as the cart; consent flag reads now share one `hasStoredConsent()` helper instead of three copies of the magic string.
- Parsing is whole-draft-or-nothing: corrupt or tampered payloads restore an empty form, never a half-filled one. 13 unit tests on the parse/serialize seam.
- `/sukces` clears the draft as soon as it loads with a `session_id`, so a slow webhook can't leave PII behind after a completed purchase.
- Restore cannot auto-open the paczkomat map: `paczkomatOpenRequested` only fires in `selectShippingMethod`, never from restored state.

## Test plan
- [ ] Fill form → go to shop → back to cart → method, point, address, note restored
- [ ] Close tab → reopen → form empty
- [ ] Decline cookie consent → nothing in sessionStorage, checkout still submits
- [ ] Complete checkout → return to cart → draft gone
- [ ] Restore with paczkomat selected → map does not auto-open

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)