### PR TITLE
refactor: remove dead separator allowances from checkout phone regex

### DIFF
--- a/src/checkout/validateCheckoutDraft.ts
+++ b/src/checkout/validateCheckoutDraft.ts
@@ -39,7 +39,7 @@ export function validateCheckoutDraft(draft: CheckoutDraft): CheckoutValidation 
   if (!/^\d{2}-\d{3}$/.test(draft.address.postalCode)) {
     fieldErrors.postalCode = "Kod pocztowy powinien mieć format XX-XXX";
   }
-  if (!/^(\+48\s?)?(\d[\s-]?){9}$/.test(draft.address.phone.replace(/\s|-/g, ""))) {
+  if (!/^(\+48)?\d{9}$/.test(draft.address.phone.replace(/[\s-]/g, ""))) {
     fieldErrors.phone = "Podaj poprawny numer telefonu (9 cyfr)";
   }
 


### PR DESCRIPTION
## Summary
- Simplify the checkout phone regex to `/^(\+48)?\d{9}$/` — separators are stripped before the test runs, so the old `\s?` and `[\s-]?` allowances were dead code
- No behavior change; existing tests in `validateCheckoutDraft.test.ts` pass unchanged (12/12), full suite green (143/143)

## Test plan
- [x] `npx vitest run src/checkout/validateCheckoutDraft.test.ts`
- [x] `npx vitest run` (full suite)
- [x] `npx tsc --noEmit`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)