### PR TITLE
fix: Polish fallback for checkout network errors (#62)

### DIFF
--- a/src/checkout/checkoutErrorMessage.test.ts
+++ b/src/checkout/checkoutErrorMessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "../lib/api";
+import { checkoutErrorMessage, CHECKOUT_ERROR_FALLBACK } from "./checkoutErrorMessage";
+
+describe("checkoutErrorMessage", () => {
+  it("passes through server-provided messages (e.g. the 409 stock error)", () => {
+    const err = new ApiError("Brak wystarczającej ilości produktu w magazynie", 409);
+    expect(checkoutErrorMessage(err)).toBe("Brak wystarczającej ilości produktu w magazynie");
+  });
+
+  it("hides the browser's raw TypeError when the backend is unreachable (#62)", () => {
+    expect(checkoutErrorMessage(new TypeError("Failed to fetch"))).toBe(CHECKOUT_ERROR_FALLBACK);
+  });
+
+  it("falls back for plain Errors — only ApiError means the server spoke", () => {
+    expect(checkoutErrorMessage(new Error("anything"))).toBe(CHECKOUT_ERROR_FALLBACK);
+  });
+
+  it("falls back for an ApiError with an empty message", () => {
+    expect(checkoutErrorMessage(new ApiError("", 500))).toBe(CHECKOUT_ERROR_FALLBACK);
+  });
+
+  it("falls back for non-Error throws", () => {
+    expect(checkoutErrorMessage("string")).toBe(CHECKOUT_ERROR_FALLBACK);
+    expect(checkoutErrorMessage(undefined)).toBe(CHECKOUT_ERROR_FALLBACK);
+  });
+});

--- a/src/checkout/checkoutErrorMessage.ts
+++ b/src/checkout/checkoutErrorMessage.ts
@@ -1,0 +1,14 @@
+import { ApiError } from "../lib/api";
+
+export const CHECKOUT_ERROR_FALLBACK = "Nie udało się przejść do płatności. Spróbuj ponownie.";
+
+/**
+ * Maps a checkout submit failure to the message shown to the customer.
+ * Only ApiError messages pass through — those come from our backend and are
+ * already Polish (e.g. the 409 stock error). Anything else (fetch TypeError
+ * on network failure, unexpected throws) gets the Polish fallback, never the
+ * browser's raw English "Failed to fetch" (#62).
+ */
+export function checkoutErrorMessage(err: unknown): string {
+  return err instanceof ApiError && err.message ? err.message : CHECKOUT_ERROR_FALLBACK;
+}

--- a/src/checkout/useCheckout.ts
+++ b/src/checkout/useCheckout.ts
@@ -4,6 +4,7 @@ import { apiFetch } from "../lib/api";
 import { useCookieConsent } from "../hooks/useCookieConsent";
 import { hasStoredConsent } from "../context/cookie-consent-context";
 import { validateCheckoutDraft } from "./validateCheckoutDraft";
+import { checkoutErrorMessage } from "./checkoutErrorMessage";
 import { buildCheckoutRequest } from "./buildCheckoutRequest";
 import { loadCheckoutDraft, saveCheckoutDraft, clearCheckoutDraft } from "./checkoutDraftStorage";
 import type { CheckoutDraft, CheckoutFieldErrors, CourierAddress, PaczkomatPoint } from "./types";
@@ -78,14 +79,16 @@ export function useCheckout(items: CartItem[], userId: string | null | undefined
         method: "POST",
         body: buildCheckoutRequest(draft, userId ?? null, note),
       });
-      if (!data.url) throw new Error("Nie udało się otworzyć strony płatności");
+      if (!data.url) {
+        // Not thrown: checkoutErrorMessage would swallow this specific
+        // message, since only ApiError messages pass through it.
+        setError("Nie udało się otworzyć strony płatności");
+        setLoading(false);
+        return;
+      }
       window.location.href = data.url;
     } catch (err) {
-      setError(
-        err instanceof Error && err.message
-          ? err.message
-          : "Nie udało się przejść do płatności. Spróbuj ponownie.",
-      );
+      setError(checkoutErrorMessage(err));
       setLoading(false);
     }
   }


### PR DESCRIPTION
## Summary
- Extract `checkoutErrorMessage()` — a pure function in the checkout module: only `ApiError` messages (server spoke, already Polish) pass through; everything else (fetch `TypeError`, unexpected throws) gets the Polish fallback instead of raw \"Failed to fetch\".
- The no-URL case no longer throws — it sets its specific Polish message directly, so the `ApiError`-only filter can't swallow it (resolves the open question in the issue comment).
- 5 unit tests on the message mapping (409 pass-through, network TypeError, plain Error, empty-message ApiError, non-Error throws).

## Test plan
- [x] `npx vitest run` — 148 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: stop the backend, attempt checkout → error line shows the Polish fallback

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)