### PR TITLE
docs: Stripe refund runbook (#77)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,7 @@ Premium e-commerce shop selling designer wooden picture frames at `sznytdesign.p
 **Działalność nierejestrowana (DN)** — unregistered business activity under Polish law. Allows operating commercially below a per-quarter revenue cap without formal business registration.
 
 - **Quarterly revenue cap (2026):** 10,813.50 PLN. Crossing it triggers mandatory business registration within 7 days. Cap value is set by law and changes year over year — bumped manually in code each tax year.
+- **Refunded (returned) orders don't count toward the cap** — *przychód należny* excludes the value of returned goods (art. 5 ust. 6 Prawa przedsiębiorców). The admin banner still counts them (it only sums `paid` orders), so it can only over-count — subtract refunds by hand when near the cap. Procedure: `docs/runbooks/refunds.md`.
 - **Pre-registration constraints:** can only issue `rachunek` (informal receipt), not `faktura VAT`. No NIP collection at checkout. No VAT in pricing language.
 - **Statutory 14-day refund right** for distance-purchase consumers — non-negotiable, must be reflected in regulamin.
 

--- a/docs/runbooks/refunds.md
+++ b/docs/runbooks/refunds.md
@@ -1,0 +1,70 @@
+# Runbook: Refunding a payment (Stripe)
+
+Who this is for: **both admins** — no developer knowledge needed.
+When to use it: a customer returned a frame under the 14-day right (regulamin § 6), a complaint was resolved with a refund (regulamin § 7), or an order has to be cancelled after payment.
+
+The shop has **no in-app refund flow on purpose** — the Stripe dashboard is the tool. This runbook is the whole procedure.
+
+---
+
+## The flow at a glance
+
+1. Customer emails `kontakt@sznytdesign.pl` (or uses the form at `/zwroty`).
+2. Customer ships the frame back; you receive and inspect it.
+3. You refund the payment in the Stripe dashboard (steps below) — within 14 days of receiving the returned product (regulamin § 6 pkt 6).
+4. You do the two manual follow-ups: restock decision + revenue-cap note (see below — the app does none of this automatically).
+
+## Step-by-step: refund in the Stripe dashboard
+
+1. Log in at [dashboard.stripe.com](https://dashboard.stripe.com). Make sure the toggle in the top-left is on the **live** account (not "Test mode").
+2. Find the payment. Two ways:
+   - **Payments** in the left menu → search by the customer's email, or
+   - search bar at the top → paste the customer's email or the amount.
+   - Cross-check with the order in the shop's admin panel: the amount, date, and email must match. If the customer placed several orders, verify you have the right one before refunding.
+3. Click the payment to open it, then click the **Refund** button (top right).
+4. Choose the amount:
+   - **Full refund** — the default; the whole amount is pre-filled. Use for a standard 14-day return.
+   - **Partial refund** — type a lower amount. Use when e.g. only one of two frames comes back, or you refund the product but not an extra service.
+5. Pick a reason (**Requested by customer** for returns) — optional, but it keeps the history readable.
+6. Confirm. The refund is issued immediately on Stripe's side and shows on the payment as `Refunded` (or `Partially refunded`).
+
+There is no "undo" for a refund. If you refund the wrong payment, the money goes back to that customer and you'd have to ask them to pay again — so double-check step 2.
+
+## Fees: what a refund costs us
+
+- **Stripe keeps the original processing fee.** Refunding a 300 zł order returns 300 zł to the customer, but the ~2–3% fee Stripe took on the original charge is not returned to us.
+- Stripe charges **no additional fee** for issuing the refund itself.
+- Net effect: every refund costs us the original Stripe fee. That's the cost of doing business — never try to pass it on to the customer; the regulamin (and consumer law) requires refunding the full amount they paid.
+
+## What the customer sees
+
+- The refund reaches the customer's bank account or card in roughly **5–10 business days** — the delay is on the bank's side, not ours, and we can't speed it up.
+- Stripe does not email the customer about the refund by default. **Reply to the customer's return email** confirming the refund was issued and mentioning the 5–10 business-day window — that's our confirmation message.
+
+## What the shop does NOT do automatically
+
+The backend listens only for successful payments. It does **not** react to refunds (`charge.refunded` is not handled). After you refund in Stripe:
+
+- **The order stays `paid`** in the admin panel, and its fulfillment status is untouched. That's a judgment call, not a bug — the order history should still show what happened. Use the order's tracking/notes as you see fit.
+- **Stock is NOT restored.** If the returned frame comes back in sellable condition, bump its stock by 1 manually in the admin panel. If it's damaged, leave stock as is.
+- **The revenue-cap banner keeps counting the refunded order** — see the next section.
+
+## Refunds and the DN quarterly revenue cap
+
+**Question resolved (2026-07): a refunded (returned) order does NOT count toward the działalność-nierejestrowana quarterly cap.**
+
+The cap is assessed against *przychód należny*, which the law defines as amounts due **excluding the value of returned goods, rebates, and discounts** ("po wyłączeniu wartości zwróconych towarów, udzielonych bonifikat i skont" — art. 5 ust. 6 ustawy Prawo przedsiębiorców). A full refund for a returned product removes that amount from the quarter's tally; a partial refund removes the refunded part.
+
+**But the admin cap banner does not know about refunds.** It sums every order with status `paid` in the current quarter — refunded orders included. So the banner can only **over-count**, never under-count. That's the safe direction: it will warn you *earlier* than the law requires, never later.
+
+What to do in practice:
+
+- Normally: nothing. A few refunds at our volume don't change the picture.
+- If the banner shows **90%+ or over the cap**: before panicking, subtract any refunded orders from that quarter by hand (banner total − refunded amounts) to get the legally relevant number. Check refunds in Stripe: **Payments → filter by "Refunded"**, restricted to the quarter's dates.
+- Keep the refund visible in the sales record (ewidencja sprzedaży) as a correction/zwrot entry rather than deleting the sale — the tally must stay auditable.
+
+## Related
+
+- Regulamin § 6 (14-day withdrawal) and § 7 (complaints): `src/pages/Regulamin.tsx`
+- Cap banner computation: `backend/revenue/computeQuarterRevenue.ts` (sums `paid` orders per Warsaw-time quarter)
+- Return/complaint intake: forms at `/zwroty` → email to `kontakt@sznytdesign.pl` (email-only by design, no DB workflow)

--- a/docs/runbooks/refunds.md
+++ b/docs/runbooks/refunds.md
@@ -11,7 +11,7 @@ The shop has **no in-app refund flow on purpose** — the Stripe dashboard is th
 
 1. Customer emails `kontakt@sznytdesign.pl` (or uses the form at `/zwroty`).
 2. Customer ships the frame back; you receive and inspect it.
-3. You refund the payment in the Stripe dashboard (steps below) — within 14 days of receiving the returned product (regulamin § 6 pkt 6).
+3. You refund the payment in the Stripe dashboard (steps below) — within 14 days of receiving the returned product (regulamin § 6 pkt 7).
 4. You do the two manual follow-ups: restock decision + revenue-cap note (see below — the app does none of this automatically).
 
 ## Step-by-step: refund in the Stripe dashboard
@@ -45,7 +45,7 @@ There is no "undo" for a refund. If you refund the wrong payment, the money goes
 
 The backend listens only for successful payments. It does **not** react to refunds (`charge.refunded` is not handled). After you refund in Stripe:
 
-- **The order stays `paid`** in the admin panel, and its fulfillment status is untouched. That's a judgment call, not a bug — the order history should still show what happened. Use the order's tracking/notes as you see fit.
+- **The order stays `paid`** in the admin panel, and its fulfillment status is untouched. That's a judgment call, not a bug — the order history should still show what happened, and there's no separate "refunded" status to set. Stripe's payment page is the record of the refund.
 - **Stock is NOT restored.** If the returned frame comes back in sellable condition, bump its stock by 1 manually in the admin panel. If it's damaged, leave stock as is.
 - **The revenue-cap banner keeps counting the refunded order** — see the next section.
 
@@ -65,6 +65,6 @@ What to do in practice:
 
 ## Related
 
-- Regulamin § 6 (14-day withdrawal) and § 7 (complaints): `src/pages/Regulamin.tsx`
+- Regulamin § 6 (14-day withdrawal) and § 7 (complaints): [sznytdesign.pl/regulamin](https://sznytdesign.pl/regulamin) (source: `src/pages/Regulamin.tsx`)
 - Cap banner computation: `backend/revenue/computeQuarterRevenue.ts` (sums `paid` orders per Warsaw-time quarter)
 - Return/complaint intake: forms at `/zwroty` → email to `kontakt@sznytdesign.pl` (email-only by design, no DB workflow)


### PR DESCRIPTION
## Summary
- New `docs/runbooks/refunds.md`: dashboard refund steps (full/partial), fee behavior, what the app does NOT do after a refund (order stays `paid`, stock not restored), customer-visible 5–10 business-day timeline, link to the regulamin return flow.
- Resolves the open DN-cap question: returned goods are excluded from *przychód należny* (art. 5 ust. 6 Prawa przedsiębiorców), so refunded orders legally don't count toward the quarterly cap. The banner (`computeQuarterRevenue.ts` sums `paid` orders) keeps counting them, so it can only over-count — documented as the safe direction, with a manual-subtraction procedure near the cap.
- One-bullet CONTEXT.md addition recording the resolved domain rule.

## Test plan
- [ ] Read the runbook as a non-developer — every step doable from Stripe dashboard + admin panel alone
- [ ] Spot-check citations: regulamin § 6 pkt 7, webhook handles only `checkout.session.completed`, `/revenue/quarter` sums `paid` orders

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
