### PR TITLE
docs: demo-first replan — CONTEXT.md launch section + new triage labels

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,9 +29,8 @@ Premium e-commerce shop selling designer wooden picture frames at `sznytdesign.p
 - **Apaczka / Sendit** — Polish shipping-label aggregators. Operate on individual accounts, no business registration required. Used to manually generate paczkomat labels; admin pastes tracking back into the order.
 - **Furgonetka** — another shipping aggregator, requires business account. Blocked on registration; out of scope until then.
 - **Cutover** — the coordinated DNS + production env-var switchover from the WordPress placeholder to the React/Express app. Web-only: mail stays at cyberfolks, so MX/SPF/DKIM records never move.
-- **Soft launch** — going live silently, no marketing, with `noindex`. Brand presentation must be production-quality even though no one is being told. Happens in two phases: portfolio launch, then commerce open.
-- **Portfolio launch (week of 13 July 2026)** — phase one of the soft launch: the site is live at `sznytdesign.pl` with **all stock at 0**, so purchases are blocked. Frames are not yet manufactured (no carpenter contracted); the live site acts as a portfolio. Product/hero imagery is AI-rendered from the real frame design until real photos exist.
-- **Commerce open (31 July 2026)** — phase two: real stock is seeded and purchases become possible. Gated by a full `docs/TEST-PLAN.md` walkthrough on the live domain, including one real Stripe charge (refunded afterwards). Closes PRD #19.
+- **Soft launch** — going live on the domain silently, no marketing, with `noindex` until real photos. Deferred (2026-07-13 demo-first replan) until real products, photos, and descriptions exist — date TBD. Gated by the `docs/TEST-PLAN.md` walkthrough (#31/#85), including one real Stripe charge (refunded afterwards). Closes PRD #19.
+- **Recruiter demo** — free `.vercel.app` deployment (Vercel + Render + Neon + Clerk dev, `VITE_DEMO_MODE=true`) that serves as Adrian's SE-portfolio artifact while the domain launch waits. Full checkout runs in **Stripe test mode** (card `4242 4242 4242 4242`); no real money moves, no emails send. Runbook: `docs/DEPLOY-DEMO.md`. This is the current milestone — the project parks once it ships; re-entry point is the `waiting-for-products` issue label.
 - **Order intake** — the module that turns a paid Stripe checkout session into a recorded `Order`: transaction, atomic stock decrement, idempotency. Lives in `backend/orders/`. The Stripe webhook route is its adapter.
 - **Line-item contract** — the agreement between checkout and order intake carried through Stripe: each product line item is stamped with `metadata.productId`; a line item without one (shipping) is skipped when recording `OrderItem`s and decrementing stock.
 - **Shipping address contract** — the flat JSON captured at checkout and stored on the Order as `shippingAddress`: `firstName`, `lastName`, `email`, `street`, `postalCode`, `city`, `phone` always present; the paczkomat point's `code` and `name` present iff `shippingMethod === "paczkomat"`. Discriminated by the Order's sibling `shippingMethod`, never by its own shape. Typed as `ShippingAddress` in `@sznyt/shared`; built only by the frontend checkout module, parsed and rendered by order intake and emails. See `docs/adr/0003-checkout-assembly-module.md`.
@@ -76,7 +75,8 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **InPost easyPack** — paczkomat picker widget.
 - **Apaczka / Sendit** — manual shipping labels (individual account).
 - **Vercel** — frontend hosting (hobby tier).
-- **Railway** — backend hosting + managed Postgres (~$5–10/mo).
+- **Railway** — backend hosting + managed Postgres (~$5–10/mo). Provisioned at real launch, not before.
+- **Render + Neon** — free-tier backend + Postgres for the recruiter demo (production stays on Railway).
 
 ## Key rules & invariants
 
@@ -85,7 +85,8 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **`stripeSessionId` is the idempotency key.** Webhook retries must be no-ops.
 - **Rachunek only pre-NIP.** No `faktura VAT` UI, no NIP field on checkout, no VAT in pricing copy until business registration ships.
 - **Quarterly revenue cap is monitored, not enforced.** Admin sees a banner with running total + 70 % / 90 % / over thresholds. Crossing it is a manual action (begin registration), not an automatic block.
-- **Stock 0 blocks purchases (portfolio phase).** During the portfolio launch every product is seeded with `stock: 0` — add-to-cart is disabled and PDP/home show "Brak w magazynie". Commerce opens by seeding real stock, not by a feature flag. Do not "fix" the empty shop by seeding stock.
+- **Production launches only with real products.** The domain flip waits for frames, photos, and descriptions (issues labeled `waiting-for-products`). The interim public artifact is the recruiter demo, not the domain.
+- **Seed defaults to stock 0.** `seed.js` seeds `stock: 0` unless `SEED_STOCK=<n>` is set — fail-safe toward an unpurchasable shop (stock 0 disables add-to-cart and shows "Brak w magazynie"). The demo seeds with `SEED_STOCK` so recruiters can complete test purchases.
 - **`noindex` until real photos.** Site ships with `<meta name="robots" content="noindex">` at the layout level. Lifted only after **real** product photos land — AI-rendered placeholder imagery does not lift it.
 - **Admin must work at 375 px.** Wife uses phone as primary admin device.
 - **Returns and complaints are email-only.** No DB workflow. Forms post to `kontakt@sznytdesign.pl`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -49,6 +49,8 @@ When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the 
 | Label     | Meaning                                                                  |
 | --------- | ------------------------------------------------------------------------ |
 | `blocked` | Cannot proceed due to external dependency. Pair with type label; priority may be omitted until unblocked. |
+| `demo-now` | Finish before parking the project — part of the recruiter-demo milestone (2026-07-13 demo-first replan). |
+| `waiting-for-products` | Parked until real frames/photos/descriptions exist. The re-entry filter when work resumes: `gh issue list --label waiting-for-products`. |
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- CONTEXT.md: 'portfolio launch week of 13 July' + 'commerce open 31 July' replaced with the demo-first reality — **Recruiter demo** (free .vercel.app, Stripe test-mode checkout, DEPLOY-DEMO.md) is the current milestone; **soft launch on the domain is deferred** until real products exist (date TBD). Stock-0 invariant reworded around the SEED_STOCK default (#92); Render + Neon added to external services.
- triage-labels.md: documents the two new status modifiers `demo-now` and `waiting-for-products`.

## Why
Replan decided 2026-07-13 in-session: shop won't go live 31 July; Adrian needs a shareable portfolio demo for recruiters now, and the project parks after it ships. See the replan comment on #19.

## Test plan
- [ ] Docs-only; render check

🤖 Generated with [Claude Code](https://claude.com/claude-code)