### PR TITLE
chore: privacy policy accuracy + CONTEXT.md corrections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,17 +13,18 @@ Premium e-commerce shop selling designer wooden picture frames at `sznytdesign.p
 
 - **Quarterly revenue cap (2026):** 10,813.50 PLN. Crossing it triggers mandatory business registration within 7 days. Cap value is set by law and changes year over year — bumped manually in code each tax year.
 - **Refunded (returned) orders don't count toward the cap** — *przychód należny* excludes the value of returned goods (art. 5 ust. 6 Prawa przedsiębiorców). The admin banner still counts them (it only sums `paid` orders), so it can only over-count — subtract refunds by hand when near the cap. Procedure: `docs/runbooks/refunds.md`.
-- **Pre-registration constraints:** can only issue `rachunek` (informal receipt), not `faktura VAT`. No NIP collection at checkout. No VAT in pricing language.
+- **Pre-registration constraints:** issues `rachunek` on the buyer's request (art. 87 § 1 Ordynacji podatkowej) and `faktura bez VAT` on the buyer's request made within 3 months (art. 106b ust. 3 pkt 2 ustawy o VAT) — never `faktura VAT`. No NIP collection at checkout. No VAT in pricing language.
 - **Statutory 14-day refund right** for distance-purchase consumers — non-negotiable, must be reflected in regulamin.
 
 ## Domain glossary
 
 - **Działalność nierejestrowana (DN)** — unregistered business activity. Polish legal regime allowing commerce below a quarterly revenue cap without business registration.
 - **NIP** — Polish tax identification number. Required to issue `faktura VAT`. Not collected pre-registration.
-- **Rachunek** — informal receipt. What customers get pre-NIP. Line items, totals, seller and buyer data, no VAT or NIP.
+- **Rachunek** — informal receipt, issued on the buyer's request. Line items, totals, seller and buyer data, no VAT or NIP.
+- **Faktura bez VAT** — invoice without VAT (sale exempt under art. 113 ustawy o VAT). Mandatory when the buyer requests one within 3 months of delivery; does NOT require business registration or a seller NIP.
 - **Faktura VAT** — VAT invoice. Requires NIP. Blocked until business registration.
 - **Regulamin** — terms of service. Legal requirement under Polish e-commerce law. Lives at `src/pages/Regulamin.tsx`. Must declare DN status, refund right, returns/complaints procedures, data controller.
-- **Polityka prywatności** — privacy policy. Lives at `src/pages/PolitykaPrywatnosci.tsx`. Must describe cookie usage, data processing basis, controller.
+- **Polityka prywatności** — privacy policy. Lives at `src/pages/PolitykaPrywatnosci.tsx`. Must describe browser storage (art. 399 Prawa komunikacji elektronicznej), data processing bases, third-country transfers (Stripe/Clerk DPF), controller — consistent with the regulamin.
 - **Paczkomat / InPost** — Polish parcel locker network. Most common delivery method for low-value e-commerce.
 - **easyPack** — InPost's JS widget for paczkomat selection at checkout. No business account required.
 - **Apaczka / Sendit** — Polish shipping-label aggregators. Operate on individual accounts, no business registration required. Used to manually generate paczkomat labels; admin pastes tracking back into the order.
@@ -83,7 +84,7 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **Atomic stock decrement.** Stock decrements happen in the Stripe webhook handler inside a Prisma transaction. Never decrement on cart-add or checkout-start — only on payment confirmation.
 - **Stripe webhook is the source of truth.** Order status transitions to `paid` only via the webhook. `/sukces` is a UX page, not a state transition.
 - **`stripeSessionId` is the idempotency key.** Webhook retries must be no-ops.
-- **Rachunek only pre-NIP.** No `faktura VAT` UI, no NIP field on checkout, no VAT in pricing copy until business registration ships.
+- **Rachunek / faktura bez VAT on request, pre-NIP.** Both issued manually by email on the buyer's request (regulamin § 5 pkt 3). No `faktura VAT` UI, no NIP field on checkout, no VAT in pricing copy until business registration ships.
 - **Quarterly revenue cap is monitored, not enforced.** Admin sees a banner with running total + 70 % / 90 % / over thresholds. Crossing it is a manual action (begin registration), not an automatic block.
 - **Production launches only with real products.** The domain flip waits for frames, photos, and descriptions (issues labeled `waiting-for-products`). The interim public artifact is the recruiter demo, not the domain.
 - **Seed defaults to stock 0.** `seed.js` seeds `stock: 0` unless `SEED_STOCK=<n>` is set — fail-safe toward an unpurchasable shop (stock 0 disables add-to-cart and shows "Brak w magazynie"). The demo seeds with `SEED_STOCK` so recruiters can complete test purchases.

--- a/src/pages/PolitykaPrywatnosci.tsx
+++ b/src/pages/PolitykaPrywatnosci.tsx
@@ -26,7 +26,7 @@ const BROWSER_STORAGE: BrowserStorageRow[] = [
     item: "Sesja użytkownika (__session, __client_uat)",
     mechanism: "cookies (Clerk)",
     purpose: "Utrzymanie zalogowania na koncie Klienta. Ustawiane dopiero, gdy korzystasz z logowania lub rejestracji.",
-    lifetime: "Do wylogowania lub wygaśnięcia sesji — domyślnie 7 dni od ostatniej aktywności; token sesji odświeżany jest automatycznie co ok. 60 sekund.",
+    lifetime: "Do wylogowania lub wygaśnięcia sesji — domyślnie 7 dni od ostatniej aktywności, zgodnie z ustawieniami Clerk.",
   },
 ];
 

--- a/src/pages/PolitykaPrywatnosci.tsx
+++ b/src/pages/PolitykaPrywatnosci.tsx
@@ -1,5 +1,35 @@
 import Seo from "../components/Seo";
 
+const SELLER_PHONE = "+48 534 218 485";
+
+interface BrowserStorageRow {
+  item: string;
+  mechanism: string;
+  purpose: string;
+  lifetime: string;
+}
+
+const BROWSER_STORAGE: BrowserStorageRow[] = [
+  {
+    item: "Koszyk (cart)",
+    mechanism: "localStorage",
+    purpose: "Zapamiętanie zawartości koszyka między wizytami.",
+    lifetime: "Do złożenia zamówienia, opróżnienia koszyka lub wyczyszczenia danych przeglądarki.",
+  },
+  {
+    item: "Szkic zamówienia (checkout_draft)",
+    mechanism: "sessionStorage",
+    purpose: "Zachowanie danych formularza zamówienia w trakcie sesji, np. przy powrocie ze strony płatności.",
+    lifetime: "Usuwany po złożeniu zamówienia; wygasa najpóźniej z zamknięciem karty przeglądarki.",
+  },
+  {
+    item: "Sesja użytkownika (__session, __client_uat)",
+    mechanism: "cookies (Clerk)",
+    purpose: "Utrzymanie zalogowania na koncie Klienta. Ustawiane dopiero, gdy korzystasz z logowania lub rejestracji.",
+    lifetime: "Do wylogowania lub wygaśnięcia sesji — domyślnie 7 dni od ostatniej aktywności; token sesji odświeżany jest automatycznie co ok. 60 sekund.",
+  },
+];
+
 function PolitykaPrywatnosci() {
   return (
     <main className="bg-warm-white px-6 py-16 md:py-24">
@@ -10,13 +40,13 @@ function PolitykaPrywatnosci() {
       <div className="max-w-3xl mx-auto">
         <p className="font-dm-sans text-xs text-accent tracking-[0.3em] uppercase mb-4">Informacje prawne</p>
         <h1 className="font-cormorant text-4xl md:text-5xl text-near-black font-light mb-2">Polityka prywatności</h1>
-        <p className="font-dm-sans text-xs text-secondary-text mb-12">Obowiązuje od: 1 maja 2026 r.</p>
+        <p className="font-dm-sans text-xs text-secondary-text mb-12">Obowiązuje od: 13 lipca 2026 r.</p>
 
         <div className="font-dm-sans text-sm text-near-black leading-relaxed flex flex-col gap-10">
 
           <section>
             <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">1. Administrator danych</h2>
-            <p className="text-secondary-text">Administratorem Twoich danych osobowych jest <strong className="text-near-black">Adrian Imioło</strong> prowadzący działalność nierejestrowaną pod nazwą <strong className="text-near-black">Sznyt Design</strong>, Bolesława Śmiałego 8/24, 70-351 Szczecin, e-mail: kontakt@sznytdesign.pl.</p>
+            <p className="text-secondary-text">Administratorem Twoich danych osobowych jest <strong className="text-near-black">Adrian Imioło</strong> prowadzący działalność nierejestrowaną pod nazwą <strong className="text-near-black">Sznyt Design</strong>, Bolesława Śmiałego 8/24, 70-351 Szczecin, e-mail: kontakt@sznytdesign.pl, tel.: <strong className="text-near-black">{SELLER_PHONE}</strong>.</p>
           </section>
 
           <section>
@@ -24,7 +54,7 @@ function PolitykaPrywatnosci() {
             <div className="flex flex-col gap-4 text-secondary-text">
               <div>
                 <p className="text-near-black font-medium mb-1">Realizacja zamówień</p>
-                <p>Imię, nazwisko, adres dostawy, adres e-mail, numer telefonu, dane płatności (przetwarzane przez Stripe). Podstawa: art. 6 ust. 1 lit. b RODO (wykonanie umowy). Czas przechowywania: 5 lat od końca roku, w którym zamówienie zostało zrealizowane (obowiązek podatkowy).</p>
+                <p>Imię, nazwisko, adres dostawy, adres e-mail, numer telefonu, dane płatności (przetwarzane przez Stripe). Podstawa: art. 6 ust. 1 lit. b RODO (wykonanie umowy), a w zakresie przechowywania dokumentacji sprzedaży na potrzeby podatkowe — art. 6 ust. 1 lit. c RODO (obowiązek prawny). Czas przechowywania: 5 lat od końca roku, w którym zamówienie zostało zrealizowane.</p>
               </div>
               <div>
                 <p className="text-near-black font-medium mb-1">Konto użytkownika (Clerk)</p>
@@ -38,25 +68,33 @@ function PolitykaPrywatnosci() {
                 <p className="text-near-black font-medium mb-1">Newsletter (planowany)</p>
                 <p>Adres e-mail. Podstawa: art. 6 ust. 1 lit. a RODO (zgoda). Czas przechowywania: do momentu wycofania zgody lub wypisania się z listy.</p>
               </div>
-              <div>
-                <p className="text-near-black font-medium mb-1">Analityka (Google Analytics 4 — planowana)</p>
-                <p>Anonimowe dane o ruchu na stronie (strony odwiedzane, źródło wejścia, urządzenie). Podstawa: art. 6 ust. 1 lit. a RODO (zgoda na cookies analityczne). Czas przechowywania: zgodnie z ustawieniami GA4 (domyślnie 14 miesięcy).</p>
-              </div>
+              <p>Podanie danych oznaczonych w formularzu zamówienia jako wymagane jest warunkiem zawarcia i wykonania umowy sprzedaży — bez tych danych nie możemy przyjąć ani zrealizować zamówienia. Podanie pozostałych danych jest dobrowolne.</p>
             </div>
           </section>
 
           <section>
-            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">3. Podmioty przetwarzające dane (procesorzy)</h2>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">3. Odbiorcy danych</h2>
             <ul className="flex flex-col gap-3 text-secondary-text">
-              <li><strong className="text-near-black">Stripe Inc.</strong> — obsługa płatności online. Dane kart i transakcji przetwarzane są wyłącznie przez Stripe zgodnie z ich polityką prywatności (stripe.com/privacy).</li>
-              <li><strong className="text-near-black">Clerk Inc.</strong> — zarządzanie kontami użytkowników i uwierzytelnianie. Polityka prywatności: clerk.com/privacy.</li>
-              <li><strong className="text-near-black">Google LLC (GA4)</strong> — analityka ruchu na stronie (planowana). Polityka prywatności: policies.google.com/privacy.</li>
-              <li><strong className="text-near-black">Dostawcy hostingu</strong> — Vercel (frontend), Railway (backend i baza danych). Dane przechowywane są na serwerach w UE lub z odpowiednimi zabezpieczeniami transferu.</li>
+              <li><strong className="text-near-black">Stripe Payments Europe, Ltd.</strong> (Irlandia) — obsługa płatności online. W zakresie realizacji płatności dla Sklepu Stripe działa jako podmiot przetwarzający; w zakresie zapobiegania oszustwom i wypełniania własnych obowiązków prawnych Stripe działa jako niezależny administrator danych. Dane kart przetwarzane są wyłącznie przez Stripe zgodnie z jego polityką prywatności (stripe.com/privacy).</li>
+              <li><strong className="text-near-black">Clerk, Inc.</strong> — zarządzanie kontami użytkowników i uwierzytelnianie (podmiot przetwarzający). Polityka prywatności: clerk.com/privacy.</li>
+              <li><strong className="text-near-black">Dostawcy hostingu</strong> — Vercel (frontend), Railway (backend i baza danych).</li>
             </ul>
           </section>
 
           <section>
-            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">4. Twoje prawa (RODO)</h2>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">4. Przekazywanie danych poza EOG</h2>
+            <div className="flex flex-col gap-3 text-secondary-text">
+              <p>Część odbiorców danych ma siedzibę w Stanach Zjednoczonych, dlatego dane mogą być przekazywane poza Europejski Obszar Gospodarczy:</p>
+              <ul className="list-disc list-outside ml-5 flex flex-col gap-2">
+                <li><strong className="text-near-black">Stripe</strong> — umowa zawierana jest ze Stripe Payments Europe, Ltd. z siedzibą w Irlandii. Przekazanie danych do Stripe, Inc. (USA) odbywa się na podstawie decyzji Komisji Europejskiej stwierdzającej odpowiedni stopień ochrony — Stripe, Inc. posiada aktywny certyfikat EU–U.S. Data Privacy Framework — a uzupełniająco na podstawie standardowych klauzul umownych (SCC), zgodnie z umową powierzenia Stripe (stripe.com/legal/dpa).</li>
+                <li><strong className="text-near-black">Clerk, Inc.</strong> (USA) — posiada aktywny certyfikat EU–U.S. Data Privacy Framework (clerk.com/legal/dpf); uzupełniająco stosowane są standardowe klauzule umowne (SCC), zgodnie z umową powierzenia Clerk (clerk.com/legal/dpa).</li>
+              </ul>
+              <p>Dane hostingowe przechowywane są na serwerach w UE lub przekazywane z zastosowaniem analogicznych zabezpieczeń. Kopię stosowanych zabezpieczeń możesz uzyskać, kontaktując się z nami.</p>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">5. Twoje prawa (RODO)</h2>
             <p className="text-secondary-text mb-3">Masz prawo do:</p>
             <ul className="list-disc list-outside ml-5 flex flex-col gap-2 text-secondary-text">
               <li><strong className="text-near-black">dostępu</strong> do swoich danych,</li>
@@ -72,37 +110,45 @@ function PolitykaPrywatnosci() {
           </section>
 
           <section>
-            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">5. Polityka cookies</h2>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">6. Dane przechowywane w przeglądarce</h2>
             <div className="flex flex-col gap-4 text-secondary-text">
-              <p>Strona sznytdesign.pl używa plików cookies i podobnych technologii przechowywania danych w przeglądarce.</p>
-              <div>
-                <p className="text-near-black font-medium mb-2">Rodzaje używanych cookies:</p>
-                <ul className="flex flex-col gap-3">
-                  <li>
-                    <p className="text-near-black">Niezbędne (zawsze aktywne)</p>
-                    <p>Koszyk zakupowy (localStorage) — przechowuje zawartość koszyka. Sesja użytkownika (Clerk) — utrzymuje zalogowanie. Zgoda na cookies (localStorage) — zapamiętuje Twój wybór.</p>
-                  </li>
-                  <li>
-                    <p className="text-near-black">Płatności</p>
-                    <p>Stripe używa własnych cookies niezbędnych do obsługi bezpiecznych płatności.</p>
-                  </li>
-                  <li>
-                    <p className="text-near-black">Analityczne (wymagają zgody)</p>
-                    <p>Google Analytics 4 — planowane. Używane do analizy ruchu na stronie w celu jej ulepszania. Aktywowane tylko po wyrażeniu zgody.</p>
-                  </li>
-                </ul>
+              <p>Strona sznytdesign.pl przechowuje na Twoim urządzeniu wyłącznie dane niezbędne do świadczenia usług, których sam żądasz (koszyk, złożenie zamówienia, zalogowanie). Zgodnie z art. 399 ust. 2 ustawy z dnia 12 lipca 2024 r. — Prawo komunikacji elektronicznej takie przechowywanie nie wymaga zgody — dlatego strona nie wyświetla banera cookies. Nie używamy cookies analitycznych ani marketingowych.</p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-left border-collapse">
+                  <thead>
+                    <tr className="border-b border-borders">
+                      <th className="py-2 pr-4 text-near-black font-medium">Element</th>
+                      <th className="py-2 pr-4 text-near-black font-medium">Mechanizm</th>
+                      <th className="py-2 pr-4 text-near-black font-medium">Cel</th>
+                      <th className="py-2 text-near-black font-medium">Czas przechowywania</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {BROWSER_STORAGE.map(function renderStorageRow(row) {
+                      return (
+                        <tr key={row.item} className="border-b border-borders align-top">
+                          <td className="py-3 pr-4 text-near-black">{row.item}</td>
+                          <td className="py-3 pr-4">{row.mechanism}</td>
+                          <td className="py-3 pr-4">{row.purpose}</td>
+                          <td className="py-3">{row.lifetime}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
-              <p>Zgodę na cookies analityczne możesz wycofać w każdej chwili, klikając „Ustawienia cookies" lub czyszcząc dane przeglądarki. Nie wpływa to na działanie sklepu.</p>
+              <p>Płatność odbywa się po przekierowaniu na strony Stripe — cookies niezbędne do bezpiecznej obsługi płatności Stripe zapisuje na własnych stronach, zgodnie ze swoją polityką prywatności.</p>
+              <p>Powyższe dane możesz w każdej chwili usunąć, czyszcząc dane przeglądarki dla strony sznytdesign.pl. Nie wpływa to na działanie sklepu poza utratą zawartości koszyka i wylogowaniem.</p>
             </div>
           </section>
 
           <section>
-            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">6. Newsletter</h2>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">7. Newsletter</h2>
             <p className="text-secondary-text">Planujemy uruchomienie newslettera. Zapisując się, wyrażasz zgodę na przesyłanie informacji o nowościach i promocjach Sznyt Design. Możesz zrezygnować z subskrypcji w dowolnym momencie, klikając link w stopce każdej wiadomości. Twój adres e-mail nie będzie udostępniany osobom trzecim.</p>
           </section>
 
           <section>
-            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">7. Zmiany polityki prywatności</h2>
+            <h2 className="font-cormorant text-2xl text-near-black font-light mb-4">8. Zmiany polityki prywatności</h2>
             <p className="text-secondary-text">Zastrzegamy sobie prawo do zmian niniejszej Polityki. O istotnych zmianach poinformujemy e-mailem lub komunikatem na stronie. Aktualna wersja dostępna jest zawsze pod adresem sznytdesign.pl/polityka-prywatnosci.</p>
           </section>
 


### PR DESCRIPTION
## Summary

Implements #91 (legal audit follow-up for the privacy policy). Source: `docs/research/2026-07-13-legal-audit-regulamin-privacy.md`.

**`src/pages/PolitykaPrywatnosci.tsx` (rewrite):**
- Storage inventory table matching what the code actually stores post-#89: `cart` (localStorage), `checkout_draft` (sessionStorage, cleared on order success), Clerk cookies `__session`/`__client_uat` (only when logging in, default 7-day session)
- Phantom "Ustawienia cookies" control removed; section now cites **art. 399 ust. 2 PKE** and explains why there is no cookie banner (everything stored is strictly necessary)
- Stripe described as **processor + independent controller**, contracting entity **Stripe Payments Europe, Ltd.**; note that Stripe's cookies are set on Stripe's own pages during payment
- New **third-country transfers** section: Stripe — active EU-U.S. DPF (verified 2026-07-13 at dataprivacyframework.gov + stripe.com/legal/data-privacy-framework) with SCC fallback (verified in stripe.com/legal/dpa); Clerk — active EU-U.S. DPF (clerk.com/legal/dpf) with SCC fallback (clerk.com/legal/dpa)
- Art. 13(2)(e) RODO sentence: order data is a contractual requirement; without it no order
- GA4 section removed until analytics ships; **art. 6(1)(c)** added as basis for the 5-year tax-retention leg
- Phone **+48 534 218 485** added; controller/contact/DN wording mirrors regulamin § 1; effective date aligned to 13 lipca 2026

**`CONTEXT.md`:** rachunek/faktura framing corrected — rachunek on request, **faktura bez VAT mandatory on request** (art. 106b ust. 3 pkt 2 ustawy o VAT), only faktura VAT / NIP collection stays blocked.

**Runbook criterion:** already satisfied on main — `docs/runbooks/refunds.md` gained the art. 32 ADR-declaration section in #90.

## Review

/code-review ran (Standards + Spec agents): no standard violations; spec reviewer's two accuracy flags resolved (Stripe SCC claim verified against Stripe's DPA and kept; Clerk 60-second token detail dropped as drift-prone). Noted follow-up idea: extract a shared seller-identity constant used by both legal pages.

## Test plan

- [x] `tsc -b`, `eslint`, `vitest run` (164/164) pass
- [ ] **HITL: Adrian reads the policy copy and signs off before merge** (AC10)
- [ ] Visual check at `/polityka-prywatnosci` (table renders, scrolls horizontally on mobile)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)