### PR TITLE
refactor: extract and integration-test the money path (#107)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,14 +7,9 @@ import {
   renderReturnRequest,
   renderComplaintRequest,
 } from "./emails/index.ts";
-import {
-  buildCheckoutLineItems,
-  paidOrderFactsFromSession,
-  normalizeOrderNote,
-  recordPaidOrder,
-  notifyOrderPlaced,
-} from "./orders/index.ts";
 import { computeQuarterRevenue } from "./revenue/index.ts";
+import { createWebhookRouter } from "./routes/webhook.js";
+import { createCheckoutRouter } from "./routes/checkout.js";
 import { FULFILLMENT_STATUSES } from "@sznyt/shared";
 
 /**
@@ -36,18 +31,12 @@ export function createApp({ auth, stripe, mailer, prisma }) {
   // express-rate-limit to see real client IPs instead of the proxy's.
   app.set("trust proxy", 1);
 
-  // Public forms trigger outbound SMTP + DB writes; checkout calls Stripe.
-  // The honeypot filters dumb bots, this stops dumb loops.
+  // Public forms trigger outbound SMTP + DB writes. The honeypot filters
+  // dumb bots, this stops dumb loops. (Checkout has its own limiter in
+  // routes/checkout.js.)
   const formLimiter = rateLimit({
     windowMs: 60 * 1000,
     limit: 5,
-    standardHeaders: "draft-8",
-    legacyHeaders: false,
-    message: { error: "Zbyt wiele prób. Spróbuj ponownie za chwilę." },
-  });
-  const checkoutLimiter = rateLimit({
-    windowMs: 60 * 1000,
-    limit: 10,
     standardHeaders: "draft-8",
     legacyHeaders: false,
     message: { error: "Zbyt wiele prób. Spróbuj ponownie za chwilę." },
@@ -78,69 +67,14 @@ export function createApp({ auth, stripe, mailer, prisma }) {
     next();
   }
 
-  app.post(
-    "/webhook",
-    express.raw({ type: "application/json" }),
-    async (req, res) => {
-      if (!stripe) {
-        return res.status(503).json({ error: "Stripe not configured (demo mode)" });
-      }
-      const sig = req.headers["stripe-signature"];
-      let event;
-
-      try {
-        event = stripe.webhooks.constructEvent(
-          req.body,
-          sig,
-          process.env.STRIPE_WEBHOOK_SECRET,
-        );
-      } catch (err) {
-        return res.status(400).send(`Webhook error: ${err.message}`);
-      }
-      if (event.type === "checkout.session.completed") {
-        // This route is the Stripe adapter (ADR-0001): all Stripe I/O happens
-        // here, then plain facts go into the order-intake module.
-        try {
-          const session = event.data.object;
-
-          const lineItems = await stripe.checkout.sessions.listLineItems(
-            session.id,
-            { expand: ["data.price.product"], limit: 100 },
-          );
-
-          let paymentMethod = null;
-          if (session.payment_intent) {
-            try {
-              const pi = await stripe.paymentIntents.retrieve(session.payment_intent, {
-                expand: ["latest_charge"],
-              });
-              paymentMethod = pi.latest_charge?.payment_method_details?.type ?? null;
-            } catch {
-              // non-blocking — order still saves without it
-            }
-          }
-
-          const facts = paidOrderFactsFromSession(session, lineItems.data, paymentMethod);
-          const result = await recordPaidOrder(prisma, facts);
-
-          // Webhook retry for an already-recorded order — 200 no-op, and
-          // crucially no duplicate emails.
-          if (result.created) {
-            await notifyOrderPlaced(mailer, facts, result.order.id);
-          }
-        } catch (err) {
-          // Must return 500 so Stripe retries; a swallowed error here
-          // permanently loses a paid order.
-          console.error("Błąd przetwarzania zamówienia:", err.message);
-          return res.status(500).json({ error: "Order processing failed" });
-        }
-      }
-
-      res.json({ received: true });
-    },
-  );
+  // The money path (issue #107): webhook + checkout live in routes/, each
+  // the Stripe adapter for its direction (ADR-0001). The webhook router
+  // mounts before express.json() — signature verification needs the raw body.
+  app.use(createWebhookRouter({ stripe, prisma, mailer }));
 
   app.use(express.json());
+
+  app.use(createCheckoutRouter({ stripe, prisma }));
 
   app.get("/products", async (req, res) => {
     try {
@@ -245,64 +179,6 @@ export function createApp({ auth, stripe, mailer, prisma }) {
       res.json(contactMessage);
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
-
-  app.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
-    try {
-      if (!stripe) {
-        return res.status(503).json({ error: "Checkout disabled in demo mode" });
-      }
-      const { items, userId, shippingMethod, shippingAddress, note } = req.body;
-
-      const noteResult = normalizeOrderNote(note);
-      if (!noteResult.ok) {
-        return res.status(noteResult.status).json({ error: noteResult.error });
-      }
-
-      // Fetch the referenced products; all validation and pricing lives in the
-      // order-intake module (server-authoritative — the client only chooses
-      // ids and quantities).
-      const ids = Array.isArray(items)
-        ? items.map((item) => Number(item.id)).filter(Number.isInteger)
-        : [];
-      const products = ids.length
-        ? await prisma.product.findMany({ where: { id: { in: ids } } })
-        : [];
-
-      const result = buildCheckoutLineItems(
-        items,
-        products,
-        shippingMethod,
-        process.env.FRONTEND_URL,
-      );
-      if (!result.ok) {
-        return res.status(result.status).json({ error: result.error });
-      }
-
-      const customerEmail = shippingAddress?.email || undefined;
-
-      const session = await stripe.checkout.sessions.create({
-        payment_method_types: ["card", "p24", "blik"],
-        line_items: result.lineItems,
-        mode: "payment",
-        customer_email: customerEmail,
-        success_url: `${process.env.FRONTEND_URL}/sukces?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${process.env.FRONTEND_URL}/koszyk`,
-        metadata: {
-          ...(userId ? { userId } : {}),
-          ...(noteResult.note ? { note: noteResult.note } : {}),
-          shippingMethod,
-          shippingAddress: JSON.stringify(shippingAddress),
-        },
-      });
-      res.json({ url: session.url });
-    } catch (err) {
-      console.error(err);
-      if (err.code === "email_invalid") {
-        return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
-      }
       res.status(500).json({ error: "Błąd serwera" });
     }
   });

--- a/backend/orders/recordPaidOrder.db.test.ts
+++ b/backend/orders/recordPaidOrder.db.test.ts
@@ -3,20 +3,16 @@
  * against a real Postgres: atomic stock decrement and stripeSessionId
  * idempotency. One-time setup: `npm run test:db:prepare`.
  */
-import "dotenv/config"; // vitest doesn't load backend/.env into process.env
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
-import { PrismaClient } from "../generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
+import type { PrismaClient } from "../generated/prisma/client.js";
 import { recordPaidOrder } from "./recordPaidOrder.ts";
 import type { PaidOrderFacts } from "./types.ts";
-import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import { createTestPrisma, truncateCommerceTables } from "../test/db.ts";
 
 let prisma: PrismaClient;
 
 beforeAll(() => {
-  prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
-  });
+  prisma = createTestPrisma();
 });
 
 afterAll(async () => {
@@ -24,9 +20,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await prisma.$executeRawUnsafe(
-    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
-  );
+  await truncateCommerceTables(prisma);
 });
 
 async function seedProducts() {

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -1,0 +1,85 @@
+import express from "express";
+import { rateLimit } from "express-rate-limit";
+import { buildCheckoutLineItems, normalizeOrderNote } from "../orders/index.ts";
+
+/**
+ * Checkout-session route (issue #107) — the outbound half of the Stripe
+ * adapter (ADR-0001). Validation and pricing live in the order-intake
+ * module; this route only fetches products and talks to Stripe.
+ *
+ * @param {object} deps
+ * @param {object|null} deps.stripe  Stripe client, or null in demo mode.
+ * @param {object} deps.prisma
+ */
+export function createCheckoutRouter({ stripe, prisma }) {
+  const router = express.Router();
+
+  // Checkout calls Stripe — stop dumb loops before they become API spam.
+  const checkoutLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 10,
+    standardHeaders: "draft-8",
+    legacyHeaders: false,
+    message: { error: "Zbyt wiele prób. Spróbuj ponownie za chwilę." },
+  });
+
+  router.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
+    try {
+      if (!stripe) {
+        return res.status(503).json({ error: "Checkout disabled in demo mode" });
+      }
+      const { items, userId, shippingMethod, shippingAddress, note } = req.body;
+
+      const noteResult = normalizeOrderNote(note);
+      if (!noteResult.ok) {
+        return res.status(noteResult.status).json({ error: noteResult.error });
+      }
+
+      // Fetch the referenced products; all validation and pricing lives in the
+      // order-intake module (server-authoritative — the client only chooses
+      // ids and quantities).
+      const ids = Array.isArray(items)
+        ? items.map((item) => Number(item.id)).filter(Number.isInteger)
+        : [];
+      const products = ids.length
+        ? await prisma.product.findMany({ where: { id: { in: ids } } })
+        : [];
+
+      const result = buildCheckoutLineItems(
+        items,
+        products,
+        shippingMethod,
+        process.env.FRONTEND_URL,
+      );
+      if (!result.ok) {
+        return res.status(result.status).json({ error: result.error });
+      }
+
+      const customerEmail = shippingAddress?.email || undefined;
+
+      const session = await stripe.checkout.sessions.create({
+        payment_method_types: ["card", "p24", "blik"],
+        line_items: result.lineItems,
+        mode: "payment",
+        customer_email: customerEmail,
+        success_url: `${process.env.FRONTEND_URL}/sukces?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${process.env.FRONTEND_URL}/koszyk`,
+        metadata: {
+          ...(userId ? { userId } : {}),
+          ...(noteResult.note ? { note: noteResult.note } : {}),
+          shippingMethod,
+          shippingAddress: JSON.stringify(shippingAddress),
+        },
+      });
+      res.json({ url: session.url });
+    } catch (err) {
+      console.error(err);
+      if (err.code === "email_invalid") {
+        return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
+      }
+      res.status(500).json({ error: "Błąd serwera" });
+    }
+  });
+
+  return router;
+}

--- a/backend/routes/webhook.js
+++ b/backend/routes/webhook.js
@@ -1,0 +1,85 @@
+import express from "express";
+import {
+  paidOrderFactsFromSession,
+  recordPaidOrder,
+  notifyOrderPlaced,
+} from "../orders/index.ts";
+
+/**
+ * Stripe webhook route (issue #107). This is the Stripe adapter for order
+ * intake (ADR-0001): signature verification and all Stripe I/O happen here,
+ * then plain facts go into the order-intake module.
+ *
+ * Must be mounted BEFORE express.json() — signature verification needs the
+ * raw request body, byte for byte.
+ *
+ * @param {object} deps
+ * @param {object|null} deps.stripe  Stripe client, or null in demo mode.
+ * @param {object} deps.prisma
+ * @param {{ send: Function }} deps.mailer
+ */
+export function createWebhookRouter({ stripe, prisma, mailer }) {
+  const router = express.Router();
+
+  router.post(
+    "/webhook",
+    express.raw({ type: "application/json" }),
+    async (req, res) => {
+      if (!stripe) {
+        return res.status(503).json({ error: "Stripe not configured (demo mode)" });
+      }
+      const sig = req.headers["stripe-signature"];
+      let event;
+
+      try {
+        event = stripe.webhooks.constructEvent(
+          req.body,
+          sig,
+          process.env.STRIPE_WEBHOOK_SECRET,
+        );
+      } catch (err) {
+        return res.status(400).send(`Webhook error: ${err.message}`);
+      }
+      if (event.type === "checkout.session.completed") {
+        try {
+          const session = event.data.object;
+
+          const lineItems = await stripe.checkout.sessions.listLineItems(
+            session.id,
+            { expand: ["data.price.product"], limit: 100 },
+          );
+
+          let paymentMethod = null;
+          if (session.payment_intent) {
+            try {
+              const pi = await stripe.paymentIntents.retrieve(session.payment_intent, {
+                expand: ["latest_charge"],
+              });
+              paymentMethod = pi.latest_charge?.payment_method_details?.type ?? null;
+            } catch {
+              // non-blocking — order still saves without it
+            }
+          }
+
+          const facts = paidOrderFactsFromSession(session, lineItems.data, paymentMethod);
+          const result = await recordPaidOrder(prisma, facts);
+
+          // Webhook retry for an already-recorded order — 200 no-op, and
+          // crucially no duplicate emails.
+          if (result.created) {
+            await notifyOrderPlaced(mailer, facts, result.order.id);
+          }
+        } catch (err) {
+          // Must return 500 so Stripe retries; a swallowed error here
+          // permanently loses a paid order.
+          console.error("Błąd przetwarzania zamówienia:", err.message);
+          return res.status(500).json({ error: "Order processing failed" });
+        }
+      }
+
+      res.json({ received: true });
+    },
+  );
+
+  return router;
+}

--- a/backend/test/app.smoke.db.test.ts
+++ b/backend/test/app.smoke.db.test.ts
@@ -3,21 +3,17 @@
  * Express app runs over HTTP against the real test database, with fakes
  * injected for auth, Stripe, and mail.
  */
-import "dotenv/config"; // vitest doesn't load backend/.env into process.env
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import request from "supertest";
-import { PrismaClient } from "../generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { createTestPrisma, truncateCommerceTables } from "./db.ts";
 import { createApp } from "../app.js";
 import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
 
 let prisma: PrismaClient;
 
 beforeAll(() => {
-  prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
-  });
+  prisma = createTestPrisma();
 });
 
 afterAll(async () => {
@@ -25,9 +21,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await prisma.$executeRawUnsafe(
-    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
-  );
+  await truncateCommerceTables(prisma);
 });
 
 describe("createApp smoke test — GET /products", () => {

--- a/backend/test/checkout.db.test.ts
+++ b/backend/test/checkout.db.test.ts
@@ -4,12 +4,10 @@
  * with the outbound Stripe client faked (createdSessions records the params
  * the app would send to Stripe).
  */
-import "dotenv/config"; // vitest doesn't load backend/.env into process.env
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import request from "supertest";
-import { PrismaClient } from "../generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { createTestPrisma, truncateCommerceTables } from "./db.ts";
 import { createApp } from "../app.js";
 import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
 
@@ -17,9 +15,7 @@ let prisma: PrismaClient;
 
 beforeAll(() => {
   process.env.FRONTEND_URL = "https://shop.test";
-  prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
-  });
+  prisma = createTestPrisma();
 });
 
 afterAll(async () => {
@@ -27,9 +23,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await prisma.$executeRawUnsafe(
-    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
-  );
+  await truncateCommerceTables(prisma);
 });
 
 function buildApp({ stripe = fakeStripe() as unknown }: { stripe?: unknown } = {}) {

--- a/backend/test/checkout.db.test.ts
+++ b/backend/test/checkout.db.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration tests for the money path's checkout side (issue #107):
+ * POST /create-checkout-session over HTTP against the real test database,
+ * with the outbound Stripe client faked (createdSessions records the params
+ * the app would send to Stripe).
+ */
+import "dotenv/config"; // vitest doesn't load backend/.env into process.env
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { PrismaClient } from "../generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import { createApp } from "../app.js";
+import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+
+let prisma: PrismaClient;
+
+beforeAll(() => {
+  process.env.FRONTEND_URL = "https://shop.test";
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
+  );
+});
+
+function buildApp({ stripe = fakeStripe() as unknown }: { stripe?: unknown } = {}) {
+  const app = createApp({
+    auth: fakeAuth(),
+    stripe,
+    mailer: captureMailer(),
+    prisma,
+  });
+  return app;
+}
+
+/** The slice of Stripe session-create params the tests assert on. */
+type RecordedSessionParams = {
+  mode: string;
+  customer_email?: string;
+  success_url: string;
+  line_items: Array<{
+    quantity: number;
+    price_data: { unit_amount: number; product_data: { metadata: Record<string, string> } };
+  }>;
+  metadata: Record<string, string>;
+};
+
+const shippingAddress = {
+  firstName: "Jan",
+  lastName: "Kowalski",
+  street: "Lipowa 1",
+  city: "Poznań",
+  postalCode: "60-001",
+  phone: "+48 500 100 200",
+  email: "kupujacy@example.com",
+};
+
+describe("POST /create-checkout-session", () => {
+  it("creates a server-priced session and returns its url", async () => {
+    await prisma.product.create({
+      data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 5, imageUrl: "/ramy/debowa.jpg" },
+    });
+    const stripe = fakeStripe({ checkoutSessionUrl: "https://stripe.test/pay/cs_1" });
+    const app = buildApp({ stripe });
+
+    const res = await request(app)
+      .post("/create-checkout-session")
+      .send({
+        items: [{ id: 1, quantity: 2, price: 1 }], // client price is ignored — server-authoritative
+        userId: "user_abc",
+        shippingMethod: "dpd",
+        shippingAddress,
+        note: "Proszę o ostrożne pakowanie",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ url: "https://stripe.test/pay/cs_1" });
+
+    expect(stripe.createdSessions).toHaveLength(1);
+    const session = stripe.createdSessions[0] as RecordedSessionParams;
+    expect(session.mode).toBe("payment");
+    expect(session.customer_email).toBe("kupujacy@example.com");
+    expect(session.success_url).toBe(
+      "https://shop.test/sukces?session_id={CHECKOUT_SESSION_ID}",
+    );
+
+    // Line-item contract: product line stamped with metadata.productId and
+    // DB-priced; shipping line carries no productId.
+    const [productLine, shippingLine] = session.line_items;
+    expect(productLine.quantity).toBe(2);
+    expect(productLine.price_data.unit_amount).toBe(14999);
+    expect(productLine.price_data.product_data.metadata).toEqual({ productId: "1" });
+    expect(shippingLine.price_data.product_data.metadata).toEqual({});
+
+    expect(session.metadata).toMatchObject({
+      userId: "user_abc",
+      shippingMethod: "dpd",
+      note: "Proszę o ostrożne pakowanie",
+    });
+    expect(JSON.parse(session.metadata.shippingAddress)).toEqual(shippingAddress);
+  });
+
+  it("rejects checkout above available stock with 409 and creates no session", async () => {
+    await prisma.product.create({
+      data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 1 },
+    });
+    const stripe = fakeStripe();
+    const app = buildApp({ stripe });
+
+    const res = await request(app)
+      .post("/create-checkout-session")
+      .send({
+        items: [{ id: 1, quantity: 3 }],
+        shippingMethod: "dpd",
+        shippingAddress,
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("Niewystarczająca ilość");
+    expect(stripe.createdSessions).toHaveLength(0);
+  });
+
+  it("returns 503 in demo mode (no Stripe configured)", async () => {
+    const app = buildApp({ stripe: null });
+
+    const res = await request(app)
+      .post("/create-checkout-session")
+      .send({ items: [{ id: 1, quantity: 1 }], shippingMethod: "dpd", shippingAddress });
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/backend/test/db.ts
+++ b/backend/test/db.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared bootstrap for the DB-backed suite (npm run test:db). Single source
+ * for how tests reach the test database and reset commerce state between
+ * cases. One-time setup: `npm run test:db:prepare`.
+ */
+import "dotenv/config"; // vitest doesn't load backend/.env into process.env
+import { PrismaClient } from "../generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+
+export function createTestPrisma(): PrismaClient {
+  return new PrismaClient({
+    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
+  });
+}
+
+/** Full commerce-state reset — the suite runs single-threaded, so a global truncate is safe. */
+export async function truncateCommerceTables(prisma: PrismaClient): Promise<void> {
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
+  );
+}

--- a/backend/test/webhook.db.test.ts
+++ b/backend/test/webhook.db.test.ts
@@ -7,13 +7,11 @@
  * with `generateTestHeaderString` + a test secret. Only outbound Stripe
  * calls (listLineItems, paymentIntents) are faked.
  */
-import "dotenv/config"; // vitest doesn't load backend/.env into process.env
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import request from "supertest";
 import Stripe from "stripe";
-import { PrismaClient } from "../generated/prisma/client.js";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { createTestPrisma, truncateCommerceTables } from "./db.ts";
 import { createApp } from "../app.js";
 import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
 
@@ -29,9 +27,7 @@ let prisma: PrismaClient;
 beforeAll(() => {
   process.env.STRIPE_WEBHOOK_SECRET = TEST_WEBHOOK_SECRET;
   process.env.CONTACT_RECIPIENT = ADMIN_RECIPIENT;
-  prisma = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
-  });
+  prisma = createTestPrisma();
 });
 
 afterAll(async () => {
@@ -39,9 +35,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-  await prisma.$executeRawUnsafe(
-    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
-  );
+  await truncateCommerceTables(prisma);
 });
 
 /** Stripe line item as listLineItems returns it (price.product expanded). */

--- a/backend/test/webhook.db.test.ts
+++ b/backend/test/webhook.db.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for the money path's webhook side (issue #107): the
+ * whole app over HTTP against the real test database.
+ *
+ * Signature verification stays ON — the injected stripe client keeps the
+ * real `webhooks` object (pure HMAC, no network), and payloads are signed
+ * with `generateTestHeaderString` + a test secret. Only outbound Stripe
+ * calls (listLineItems, paymentIntents) are faked.
+ */
+import "dotenv/config"; // vitest doesn't load backend/.env into process.env
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import Stripe from "stripe";
+import { PrismaClient } from "../generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { resolveTestDatabaseUrl } from "../scripts/test-db-url.js";
+import { createApp } from "../app.js";
+import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+
+const TEST_WEBHOOK_SECRET = "whsec_test_integration_secret";
+const ADMIN_RECIPIENT = "admin@test.local";
+
+// Real signature tooling — constructEvent/generateTestHeaderString are
+// offline crypto; the API key is never used.
+const signatureKit = new Stripe("sk_test_offline_signature_only");
+
+let prisma: PrismaClient;
+
+beforeAll(() => {
+  process.env.STRIPE_WEBHOOK_SECRET = TEST_WEBHOOK_SECRET;
+  process.env.CONTACT_RECIPIENT = ADMIN_RECIPIENT;
+  prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: resolveTestDatabaseUrl() }),
+  });
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.$executeRawUnsafe(
+    'TRUNCATE TABLE "OrderItem", "Order", "Product" RESTART IDENTITY CASCADE',
+  );
+});
+
+/** Stripe line item as listLineItems returns it (price.product expanded). */
+function stripeLineItem({
+  productId,
+  name,
+  quantity,
+  unitAmount,
+}: {
+  productId: number | null;
+  name: string;
+  quantity: number;
+  unitAmount: number;
+}) {
+  return {
+    description: name,
+    quantity,
+    price: {
+      unit_amount: unitAmount,
+      product: {
+        name,
+        metadata: productId === null ? {} : { productId: String(productId) },
+      },
+    },
+  };
+}
+
+function completedSessionEvent(session: Record<string, unknown>) {
+  return {
+    id: "evt_test_1",
+    type: "checkout.session.completed",
+    data: { object: session },
+  };
+}
+
+function signedPost(
+  app: ReturnType<typeof createApp>,
+  payload: string,
+  { tamper = false }: { tamper?: boolean } = {},
+) {
+  const signature = signatureKit.webhooks.generateTestHeaderString({
+    payload,
+    secret: TEST_WEBHOOK_SECRET,
+  });
+  const body = tamper
+    ? payload.replace('"amount_total":', '"amount_total": 1,"x":')
+    : payload;
+  return request(app)
+    .post("/webhook")
+    .set("stripe-signature", signature)
+    .set("content-type", "application/json")
+    .send(body);
+}
+
+function buildApp({ lineItems = [] as unknown[] } = {}) {
+  const mailer = captureMailer();
+  const stripe = {
+    ...fakeStripe({ lineItems }),
+    // Real verification path — a forged or tampered payload must be
+    // rejected by the same code that runs in production.
+    webhooks: signatureKit.webhooks,
+  };
+  const app = createApp({ auth: fakeAuth(), stripe, mailer, prisma });
+  return { app, mailer };
+}
+
+describe("POST /webhook — checkout.session.completed", () => {
+  const session = {
+    id: "cs_test_paid_1",
+    amount_total: 32498, // 2×149.99 + 25.00 shipping, in grosze
+    payment_intent: null,
+    customer_details: { email: "kupujacy@example.com" },
+    metadata: {
+      userId: "user_abc",
+      shippingMethod: "dpd",
+      shippingAddress: JSON.stringify({
+        firstName: "Jan",
+        lastName: "Kowalski",
+        street: "Lipowa 1",
+        city: "Poznań",
+        postalCode: "60-001",
+        phone: "+48 500 100 200",
+        email: "kupujacy@example.com",
+      }),
+      note: "Proszę o ostrożne pakowanie",
+    },
+  };
+  const lineItems = [
+    stripeLineItem({ productId: 1, name: "Rama Dębowa 30×40", quantity: 2, unitAmount: 14999 }),
+    stripeLineItem({ productId: null, name: "Dostawa — DPD Kurier", quantity: 1, unitAmount: 2500 }),
+  ];
+
+  async function seedProduct() {
+    await prisma.product.create({
+      data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 },
+    });
+  }
+
+  it("accepts a validly signed payload: records the order and decrements stock", async () => {
+    await seedProduct();
+    const { app } = buildApp({ lineItems });
+
+    const res = await signedPost(app, JSON.stringify(completedSessionEvent(session)));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+
+    const orderRes = await request(app).get("/orders/by-session/cs_test_paid_1");
+    expect(orderRes.status).toBe(200);
+    expect(orderRes.body).toMatchObject({
+      status: "paid",
+      total: 324.98,
+      customerEmail: "kupujacy@example.com",
+      userId: "user_abc",
+      shippingMethod: "dpd",
+      note: "Proszę o ostrożne pakowanie",
+    });
+    expect(orderRes.body.items).toHaveLength(1); // shipping line carries no productId
+    expect(orderRes.body.items[0]).toMatchObject({
+      productId: 1,
+      quantity: 2,
+      price: 149.99,
+    });
+
+    const productRes = await request(app).get("/products/1");
+    expect(productRes.body.stock).toBe(3);
+  });
+
+  it("sends customer confirmation and admin notification emails", async () => {
+    await seedProduct();
+    const { app, mailer } = buildApp({ lineItems });
+
+    await signedPost(app, JSON.stringify(completedSessionEvent(session)));
+
+    expect(mailer.sent).toHaveLength(2);
+    const [customerEmail, adminEmail] = mailer.sent;
+    expect(customerEmail.to).toBe("kupujacy@example.com");
+    expect(customerEmail.subject).toContain("zamówieni");
+    expect(customerEmail.html).toContain("Rama Dębowa 30×40");
+    expect(adminEmail.to).toBe(ADMIN_RECIPIENT);
+    expect(adminEmail.html).toContain("Rama Dębowa 30×40");
+  });
+
+  it("rejects a tampered payload with 400 and records nothing", async () => {
+    await seedProduct();
+    const { app, mailer } = buildApp({ lineItems });
+
+    const res = await signedPost(
+      app,
+      JSON.stringify(completedSessionEvent(session)),
+      { tamper: true },
+    );
+
+    expect(res.status).toBe(400);
+    const orderRes = await request(app).get("/orders/by-session/cs_test_paid_1");
+    expect(orderRes.status).toBe(404);
+    const productRes = await request(app).get("/products/1");
+    expect(productRes.body.stock).toBe(5);
+    expect(mailer.sent).toHaveLength(0);
+  });
+
+  it("rejects an unsigned payload with 400", async () => {
+    await seedProduct();
+    const { app } = buildApp({ lineItems });
+
+    const res = await request(app)
+      .post("/webhook")
+      .set("content-type", "application/json")
+      .send(JSON.stringify(completedSessionEvent(session)));
+
+    expect(res.status).toBe(400);
+    const orderRes = await request(app).get("/orders/by-session/cs_test_paid_1");
+    expect(orderRes.status).toBe(404);
+  });
+
+  it("handles duplicate delivery idempotently: one order, one decrement, one email pair", async () => {
+    await seedProduct();
+    const { app, mailer } = buildApp({ lineItems });
+    const payload = JSON.stringify(completedSessionEvent(session));
+
+    const first = await signedPost(app, payload);
+    const second = await signedPost(app, payload);
+
+    // Stripe retries must get 200 for an already-recorded order, or it
+    // keeps redelivering forever.
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const orders = await prisma.order.findMany({
+      where: { stripeSessionId: "cs_test_paid_1" },
+    });
+    expect(orders).toHaveLength(1);
+
+    const productRes = await request(app).get("/products/1");
+    expect(productRes.body.stock).toBe(3); // decremented once, not twice
+
+    expect(mailer.sent).toHaveLength(2); // customer + admin, no retry duplicates
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /webhook` and `POST /create-checkout-session` move out of the app factory into `backend/routes/webhook.js` and `backend/routes/checkout.js` as injectable router factories — each stays the Stripe adapter for its direction (ADR-0001). Webhook router mounts before `express.json()` so signature verification keeps the raw body; the checkout rate limiter moves with its route.
- Route-level integration tests (supertest + real test Postgres) pin the money path **before** the extraction: valid signed webhook accepted (order + atomic stock decrement), tampered/unsigned rejected 400, duplicate delivery idempotent (one order, one decrement, one email pair), customer + admin emails asserted via capture-mailer, server-priced checkout session with the line-item contract, 409 oversell, 503 demo mode.
- Signature verification stays ON in tests: the injected fake keeps the real `Stripe(...).webhooks` object and payloads are signed with `generateTestHeaderString` + a test secret.
- Review follow-up: the four-times-copied DB-suite bootstrap (dotenv + Prisma adapter + truncate) is single-sourced in `backend/test/db.ts`.

## Test plan
- [x] `npm run test:db` from `backend/` — 14 passed (4 files)
- [x] `npm test` from `backend/` — 63 passed
- [x] root `npm test` — 167 passed; `npm run lint` clean
- [x] boot smoke: `npx tsx index.js` on a fresh port serves `/products` (entrypoint wiring unchanged, so `stripe listen` dev flow is untouched)

## Follow-ups (not in this PR)
- Rate-limiter config now appears twice (form vs checkout) — extract a `makeLimiter(limit)` if a third shows up.
- Routes still read `FRONTEND_URL` / `STRIPE_WEBHOOK_SECRET` from ambient env; passing them through the dependency seam would complete the #106 pattern.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)