### PR TITLE
chore: GitHub Actions CI - lint, typecheck, unit + integration (#109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+# CI gate (issue #109): lint, typecheck, unit + DB-backed integration tests.
+#
+# Hermetic by design — auth/Stripe/mail are injected fakes in the integration
+# suite (issue #106), so this workflow needs no repository secrets. E2E is
+# deliberately excluded (local-only, see issue #4).
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        # Wait until Postgres actually accepts connections before running steps
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # prisma.config.ts wants DATABASE_URL; the test suite derives/uses the
+      # _test database (test-db-url.js refuses anything not ending in _test).
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sznyt
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sznyt_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The generated client is TS source imported by backend code, so
+      # generate must precede backend typecheck and tests.
+      - name: Generate Prisma client
+        working-directory: backend
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck frontend
+        run: npm run typecheck
+
+      - name: Typecheck backend
+        run: npm run typecheck --workspace backend
+
+      - name: Unit tests (frontend)
+        run: npm test
+
+      - name: Unit tests (backend)
+        run: npm test --workspace backend
+
+      - name: Prepare test database
+        run: npm run test:db:prepare --workspace backend
+
+      - name: Integration tests (DB-backed)
+        run: npm run test:db --workspace backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
       - name: Typecheck backend
         run: npm run typecheck --workspace backend
 
-      - name: Unit tests (frontend)
+      # Root vitest sweeps everything non-DB (frontend + shared + backend
+      # unit under the root config); the next step reruns backend unit under
+      # its own pinned config, matching how each suite runs locally.
+      - name: Unit tests (root suite)
         run: npm test
 
       - name: Unit tests (backend)

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,8 +34,10 @@
   "devDependencies": {
     "@types/nodemailer": "^7.0.11",
     "@types/supertest": "^7.2.0",
+    "@types/node": "^24.10.1",
     "nodemon": "^3.1.14",
     "supertest": "^7.2.2",
+    "typescript": "~5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "tsx index.js",
     "build": "prisma generate && prisma migrate deploy",
     "seed": "tsx seed.js",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:db": "vitest run --config vitest.db.config.ts",
     "test:db:prepare": "node scripts/prepare-test-db.js"

--- a/backend/revenue/ci-red-x-check.test.ts
+++ b/backend/revenue/ci-red-x-check.test.ts
@@ -1,0 +1,9 @@
+// Deliberately failing test — verifies the CI gate turns red (#109).
+// This commit gets reverted immediately after the red X is confirmed.
+import { describe, it, expect } from "vitest";
+
+describe("CI red-X verification", () => {
+  it("fails on purpose", () => {
+    expect(true).toBe(false);
+  });
+});

--- a/backend/revenue/ci-red-x-check.test.ts
+++ b/backend/revenue/ci-red-x-check.test.ts
@@ -1,9 +1,0 @@
-// Deliberately failing test — verifies the CI gate turns red (#109).
-// This commit gets reverted immediately after the red X is confirmed.
-import { describe, it, expect } from "vitest";
-
-describe("CI red-X verification", () => {
-  it("fails on purpose", () => {
-    expect(true).toBe(false);
-  });
-});

--- a/backend/test/checkout.db.test.ts
+++ b/backend/test/checkout.db.test.ts
@@ -26,7 +26,7 @@ beforeEach(async () => {
   await truncateCommerceTables(prisma);
 });
 
-function buildApp({ stripe = fakeStripe() as unknown }: { stripe?: unknown } = {}) {
+function buildApp({ stripe = fakeStripe() as object }: { stripe?: object | null } = {}) {
   const app = createApp({
     auth: fakeAuth(),
     stripe,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "skipLibCheck": true,
+
+    /* Runtime is tsx (transpile-only), so JS files are first-class here:
+       parse them for syntax, but only typecheck the TS surface. */
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["**/*.ts", "**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,10 +57,12 @@
         "tsx": "^4.21.0"
       },
       "devDependencies": {
+        "@types/node": "^24.10.1",
         "@types/nodemailer": "^7.0.11",
         "@types/supertest": "^7.2.0",
         "nodemon": "^3.1.14",
         "supertest": "^7.2.2",
+        "typescript": "~5.9.3",
         "vitest": "^4.1.10"
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:backend": "npm --prefix backend run dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc -b",
     "test": "vitest run",
     "test:watch": "vitest",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml`: triggers on PRs and pushes to `main`; Postgres 17 service container prepared via the existing `test:db:prepare` script; gates on lint, frontend + backend typecheck, both unit suites, and the DB-backed integration suite. Zero repository secrets — auth/Stripe/mail are injected fakes (#106). E2E stays local-only (#4).
- New backend typecheck seam: `backend/tsconfig.json` (`tsc --noEmit`, JS parsed but unchecked) + `typecheck` scripts at root and backend. Fixed the one type error it surfaced (checkout test typed its stripe fake as `unknown` vs the seam's `object|null`).

## Test plan
- [x] All gates green locally (lint, 2× typecheck, 167 + 63 unit, 59 integration)
- [ ] CI green on this PR
- [ ] Deliberately broken test shows red X, then reverted (acceptance criterion)

Closes #109