### PR TITLE
refactor: shared error middleware + db-test harness dedup

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -7,6 +7,7 @@ import { createOrdersRouter } from "./routes/orders.js";
 import { createRevenueRouter } from "./routes/revenue.js";
 import { createFormsRouter } from "./routes/forms.js";
 import { createAdminAuth } from "./middleware/adminAuth.js";
+import { serverError } from "./middleware/errors.js";
 
 /**
  * App factory (issue #106). All external services come in through the
@@ -55,6 +56,10 @@ export function createApp({ auth, stripe, mailer, prisma }) {
   app.use(createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole }));
   app.use(createRevenueRouter({ prisma, auth, requireAdmin }));
   app.use(createFormsRouter({ prisma, mailer }));
+
+  // Tail error handler (issue #115) — Express 5 lands rejected async
+  // handlers here; must stay mounted after every router.
+  app.use(serverError);
 
   return app;
 }

--- a/backend/middleware/errors.js
+++ b/backend/middleware/errors.js
@@ -1,0 +1,15 @@
+/**
+ * Shared tail error handler (issue #115). Express 5 forwards rejected async
+ * handlers here automatically, so routes no longer wrap their bodies in the
+ * try/catch → 500 boilerplate; the canonical 500 shape lives in one place.
+ *
+ * Routes that map specific errors to other statuses (webhook signature → 400,
+ * checkout email_invalid → 400) still do so locally and rethrow the rest.
+ */
+export function serverError(err, req, res, next) {
+  // Mid-stream failure: the status line is already on the wire, so delegate
+  // to Express's default handler, which closes the connection.
+  if (res.headersSent) return next(err);
+  console.error(err);
+  res.status(500).json({ error: "Błąd serwera" });
+}

--- a/backend/middleware/errors.test.ts
+++ b/backend/middleware/errors.test.ts
@@ -1,24 +1,30 @@
 /**
- * Unit tests for the shared serverError middleware (issue #115): any error
- * that reaches the end of the chain becomes the one canonical 500 shape the
- * per-route try/catch blocks used to produce.
+ * Tests for the shared serverError middleware (issue #115), exercised
+ * through the real createApp wiring: a route whose prisma call rejects must
+ * come back as the one canonical 500 shape the per-route try/catch blocks
+ * used to produce. No database needed — prisma is a stub.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import express from "express";
 import request from "supertest";
-import { serverError } from "./errors.js";
+import { createApp } from "../app.js";
+import { fakeAuth, fakeStripe, captureMailer } from "../test/fakes.ts";
 
-function appWithThrowingRoute() {
-  const app = express();
-  app.get("/boom", async function boom() {
-    throw new Error("database exploded");
+function appWithPrisma(prisma: object) {
+  return createApp({
+    auth: fakeAuth(),
+    stripe: fakeStripe(),
+    mailer: captureMailer(),
+    prisma,
   });
-  app.get("/ok", function ok(_req, res) {
-    res.json({ ok: true });
-  });
-  app.use(serverError);
-  return app;
 }
+
+const explodingPrisma = {
+  product: {
+    findMany: async () => {
+      throw new Error("database exploded");
+    },
+  },
+};
 
 beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -28,16 +34,16 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("serverError", () => {
-  it("turns a rejected async handler into the canonical 500 shape", async () => {
-    const res = await request(appWithThrowingRoute()).get("/boom");
+describe("serverError middleware via createApp", () => {
+  it("turns a rejected handler into the canonical 500 shape", async () => {
+    const res = await request(appWithPrisma(explodingPrisma)).get("/products");
 
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: "Błąd serwera" });
   });
 
   it("logs the original error for diagnostics", async () => {
-    await request(appWithThrowingRoute()).get("/boom");
+    await request(appWithPrisma(explodingPrisma)).get("/products");
 
     expect(console.error).toHaveBeenCalledWith(
       expect.objectContaining({ message: "database exploded" }),
@@ -45,9 +51,11 @@ describe("serverError", () => {
   });
 
   it("does not touch successful responses", async () => {
-    const res = await request(appWithThrowingRoute()).get("/ok");
+    const healthyPrisma = { product: { findMany: async () => [] } };
+
+    const res = await request(appWithPrisma(healthyPrisma)).get("/products");
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ok: true });
+    expect(res.body).toEqual([]);
   });
 });

--- a/backend/middleware/errors.test.ts
+++ b/backend/middleware/errors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the shared serverError middleware (issue #115): any error
+ * that reaches the end of the chain becomes the one canonical 500 shape the
+ * per-route try/catch blocks used to produce.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { serverError } from "./errors.js";
+
+function appWithThrowingRoute() {
+  const app = express();
+  app.get("/boom", async function boom() {
+    throw new Error("database exploded");
+  });
+  app.get("/ok", function ok(_req, res) {
+    res.json({ ok: true });
+  });
+  app.use(serverError);
+  return app;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("serverError", () => {
+  it("turns a rejected async handler into the canonical 500 shape", async () => {
+    const res = await request(appWithThrowingRoute()).get("/boom");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Błąd serwera" });
+  });
+
+  it("logs the original error for diagnostics", async () => {
+    await request(appWithThrowingRoute()).get("/boom");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "database exploded" }),
+    );
+  });
+
+  it("does not touch successful responses", async () => {
+    const res = await request(appWithThrowingRoute()).get("/ok");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -79,7 +79,12 @@ export function createCheckoutRouter({ stripe, prisma }) {
         });
       } catch (err) {
         if (err.code === "email_invalid") {
-          console.error(err);
+          // err.message echoes the submitted address — log triage fields only,
+          // customer PII stays out of the logs
+          console.error("Stripe odrzucił adres e-mail:", {
+            code: err.code,
+            requestId: err.requestId,
+          });
           return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
         }
         throw err;

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -79,6 +79,7 @@ export function createCheckoutRouter({ stripe, prisma }) {
         });
       } catch (err) {
         if (err.code === "email_invalid") {
+          console.error(err);
           return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
         }
         throw err;

--- a/backend/routes/checkout.js
+++ b/backend/routes/checkout.js
@@ -5,7 +5,9 @@ import { buildCheckoutLineItems, normalizeOrderNote } from "../orders/index.ts";
 /**
  * Checkout-session route (issue #107) — the outbound half of the Stripe
  * adapter (ADR-0001). Validation and pricing live in the order-intake
- * module; this route only fetches products and talks to Stripe.
+ * module; this route only fetches products and talks to Stripe. The local
+ * catch only maps Stripe's email_invalid to a 400; everything else rethrows
+ * to the shared serverError middleware (issue #115).
  *
  * @param {object} deps
  * @param {object|null} deps.stripe  Stripe client, or null in demo mode.
@@ -23,8 +25,10 @@ export function createCheckoutRouter({ stripe, prisma }) {
     message: { error: "Zbyt wiele prób. Spróbuj ponownie za chwilę." },
   });
 
-  router.post("/create-checkout-session", checkoutLimiter, async (req, res) => {
-    try {
+  router.post(
+    "/create-checkout-session",
+    checkoutLimiter,
+    async function createCheckoutSession(req, res) {
       if (!stripe) {
         return res.status(503).json({ error: "Checkout disabled in demo mode" });
       }
@@ -57,29 +61,31 @@ export function createCheckoutRouter({ stripe, prisma }) {
 
       const customerEmail = shippingAddress?.email || undefined;
 
-      const session = await stripe.checkout.sessions.create({
-        payment_method_types: ["card", "p24", "blik"],
-        line_items: result.lineItems,
-        mode: "payment",
-        customer_email: customerEmail,
-        success_url: `${process.env.FRONTEND_URL}/sukces?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: `${process.env.FRONTEND_URL}/koszyk`,
-        metadata: {
-          ...(userId ? { userId } : {}),
-          ...(noteResult.note ? { note: noteResult.note } : {}),
-          shippingMethod,
-          shippingAddress: JSON.stringify(shippingAddress),
-        },
-      });
-      res.json({ url: session.url });
-    } catch (err) {
-      console.error(err);
-      if (err.code === "email_invalid") {
-        return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
+      let session;
+      try {
+        session = await stripe.checkout.sessions.create({
+          payment_method_types: ["card", "p24", "blik"],
+          line_items: result.lineItems,
+          mode: "payment",
+          customer_email: customerEmail,
+          success_url: `${process.env.FRONTEND_URL}/sukces?session_id={CHECKOUT_SESSION_ID}`,
+          cancel_url: `${process.env.FRONTEND_URL}/koszyk`,
+          metadata: {
+            ...(userId ? { userId } : {}),
+            ...(noteResult.note ? { note: noteResult.note } : {}),
+            shippingMethod,
+            shippingAddress: JSON.stringify(shippingAddress),
+          },
+        });
+      } catch (err) {
+        if (err.code === "email_invalid") {
+          return res.status(400).json({ error: "Podaj poprawny adres e-mail." });
+        }
+        throw err;
       }
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+      res.json({ url: session.url });
+    },
+  );
 
   return router;
 }

--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -8,9 +8,10 @@ import {
 
 /**
  * Public form routes (issue #108): contact, return (zwrot), and complaint
- * (reklamacja). Handlers moved verbatim from app.js. All three share one
- * rate-limit bucket, as before — a burst on any form counts against the same
- * per-IP limit.
+ * (reklamacja). All three share one rate-limit bucket — a burst on any form
+ * counts against the same per-IP limit. Contact failures propagate to the
+ * shared serverError middleware (issue #115); zwrot/reklamacja keep local
+ * catches because their 500 body carries a fallback contact address.
  *
  * @param {object} deps
  * @param {object} deps.prisma
@@ -31,34 +32,29 @@ export function createFormsRouter({ prisma, mailer }) {
   });
 
   // submit contact form
-  router.post("/contact", formLimiter, async (req, res) => {
+  router.post("/contact", formLimiter, async function submitContact(req, res) {
     const { name, email, message, _hp } = req.body;
     if (_hp) return res.json({ ok: true });
     if (!name || !email || !message) {
       return res.status(400).json({ error: "Wszystkie pola są wymagane." });
     }
+    const contactMessage = await prisma.contactMessage.create({
+      data: { name, email, message },
+    });
     try {
-      const contactMessage = await prisma.contactMessage.create({
-        data: { name, email, message },
+      await mailer.send({
+        to: process.env.CONTACT_RECIPIENT,
+        replyTo: email,
+        ...renderContactNotification({ name, email, message }),
       });
-      try {
-        await mailer.send({
-          to: process.env.CONTACT_RECIPIENT,
-          replyTo: email,
-          ...renderContactNotification({ name, email, message }),
-        });
-      } catch (emailErr) {
-        console.error("Błąd wysyłania emaila:", emailErr.message);
-      }
-      res.json(contactMessage);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
+    } catch (emailErr) {
+      console.error("Błąd wysyłania emaila:", emailErr.message);
     }
+    res.json(contactMessage);
   });
 
   // submit return form
-  router.post("/zwrot", formLimiter, async (req, res) => {
+  router.post("/zwrot", formLimiter, async function submitReturn(req, res) {
     const { orderNumber, name, email, reason, bankAccount, _hp } = req.body;
     if (_hp) return res.json({ ok: true });
     if (!orderNumber || !name || !email || !reason || !bankAccount) {
@@ -78,7 +74,7 @@ export function createFormsRouter({ prisma, mailer }) {
   });
 
   // submit complaint form
-  router.post("/reklamacja", formLimiter, async (req, res) => {
+  router.post("/reklamacja", formLimiter, async function submitComplaint(req, res) {
     const { orderNumber, name, email, description, _hp } = req.body;
     if (_hp) return res.json({ ok: true });
     if (!orderNumber || !name || !email || !description) {

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -5,10 +5,10 @@ import { FULFILLMENT_STATUSES } from "@sznyt/shared";
 /**
  * Orders routes (issue #108): admin list + fulfillment, per-user orders,
  * order detail with ownership check, and the public by-session lookup the
- * success page uses. Handler bodies moved verbatim from app.js; by-session
- * now registers before /:id (matching is unaffected — /orders/:id can't
- * match the two-segment by-session path; it just groups the multi-segment
- * routes ahead of the catch-all-ish /:id).
+ * success page uses. by-session registers before /:id (matching is
+ * unaffected — /orders/:id can't match the two-segment by-session path; it
+ * just groups the multi-segment routes ahead of the catch-all-ish /:id).
+ * Failures propagate to the shared serverError middleware (issue #115).
  *
  * @param {object} deps
  * @param {object} deps.prisma
@@ -20,21 +20,19 @@ import { FULFILLMENT_STATUSES } from "@sznyt/shared";
 export function createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole }) {
   const router = express.Router();
 
-  router.get("/orders", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
-      const orders = await prisma.order.findMany({
-        orderBy: { createdAt: "desc" },
-      });
-      res.json(orders);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
+  router.get("/orders", auth.requireAuth(), requireAdmin, async function listOrders(req, res) {
+    const orders = await prisma.order.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+    res.json(orders);
   });
 
   // update fulfillment status + tracking number
-  router.patch("/orders/:id/fulfillment", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.patch(
+    "/orders/:id/fulfillment",
+    auth.requireAuth(),
+    requireAdmin,
+    async function updateFulfillment(req, res) {
       const id = Number(req.params.id);
       const { fulfillmentStatus, trackingNumber } = req.body;
 
@@ -64,14 +62,13 @@ export function createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole
       }
 
       res.json(order);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+    },
+  );
 
-  router.get("/orders/user/:userId", auth.requireAuth(), async (req, res) => {
-    try {
+  router.get(
+    "/orders/user/:userId",
+    auth.requireAuth(),
+    async function listUserOrders(req, res) {
       const { userId } = req.params;
       if (auth.getAuth(req).userId !== userId) {
         return res.status(403).json({ error: "Forbidden" });
@@ -82,47 +79,34 @@ export function createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole
         orderBy: { createdAt: "desc" },
       });
       res.json(orders);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
+    },
+  );
+
+  router.get("/orders/by-session/:sessionId", async function getOrderBySession(req, res) {
+    const { sessionId } = req.params;
+    const order = await prisma.order.findUnique({
+      where: { stripeSessionId: sessionId },
+      include: { items: { include: { product: true } } },
+    });
+    if (!order) return res.status(404).json({ error: "Nie znaleziono zamówienia" });
+    res.json(order);
   });
 
-  router.get("/orders/by-session/:sessionId", async (req, res) => {
-    try {
-      const { sessionId } = req.params;
-      const order = await prisma.order.findUnique({
-        where: { stripeSessionId: sessionId },
-        include: { items: { include: { product: true } } },
-      });
-      if (!order) return res.status(404).json({ error: "Nie znaleziono zamówienia" });
-      res.json(order);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
+  router.get("/orders/:id", auth.requireAuth(), async function getOrder(req, res) {
+    const id = Number(req.params.id);
+    const order = await prisma.order.findUnique({
+      where: { id },
+      include: { items: { include: { product: true } } },
+    });
+    if (!order) return res.status(404).json({ error: "Nie znaleziono zamówienia" });
+    // Guest orders (userId=null) are only reachable via /orders/by-session/:sessionId —
+    // sequential ids must not expose their shipping data to other signed-in users.
+    // Admins bypass the ownership check: the admin order-detail page reads any
+    // order (guest ones included) through this endpoint.
+    if (order.userId !== auth.getAuth(req).userId && getRole(req) !== "admin") {
+      return res.status(403).json({ error: "Forbidden" });
     }
-  });
-
-  router.get("/orders/:id", auth.requireAuth(), async (req, res) => {
-    try {
-      const id = Number(req.params.id);
-      const order = await prisma.order.findUnique({
-        where: { id },
-        include: { items: { include: { product: true } } },
-      });
-      if (!order) return res.status(404).json({ error: "Nie znaleziono zamówienia" });
-      // Guest orders (userId=null) are only reachable via /orders/by-session/:sessionId —
-      // sequential ids must not expose their shipping data to other signed-in users.
-      // Admins bypass the ownership check: the admin order-detail page reads any
-      // order (guest ones included) through this endpoint.
-      if (order.userId !== auth.getAuth(req).userId && getRole(req) !== "admin") {
-        return res.status(403).json({ error: "Forbidden" });
-      }
-      res.json(order);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
+    res.json(order);
   });
 
   return router;

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -1,5 +1,11 @@
 import express from "express";
 
+/** The writable product fields — anything else in the body is dropped. */
+function productInput(body) {
+  const { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock } = body;
+  return { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock };
+}
+
 /**
  * Products routes (issue #108): public catalog reads, admin-only CRUD and
  * reorder. Failures propagate to the shared serverError middleware (issue
@@ -47,10 +53,7 @@ export function createProductsRouter({ prisma, auth, requireAdmin }) {
     auth.requireAuth(),
     requireAdmin,
     async function createProduct(req, res) {
-      const { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock } = req.body;
-      const product = await prisma.product.create({
-        data: { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock },
-      });
+      const product = await prisma.product.create({ data: productInput(req.body) });
       res.json(product);
     },
   );
@@ -60,11 +63,10 @@ export function createProductsRouter({ prisma, auth, requireAdmin }) {
     auth.requireAuth(),
     requireAdmin,
     async function updateProduct(req, res) {
-      const { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock } = req.body;
       const id = Number(req.params.id);
       const updated = await prisma.product.update({
         where: { id },
-        data: { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock },
+        data: productInput(req.body),
       });
       res.json(updated);
     },

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -2,8 +2,8 @@ import express from "express";
 
 /**
  * Products routes (issue #108): public catalog reads, admin-only CRUD and
- * reorder. Handler bodies moved verbatim from app.js; only registration
- * order changed (see the reorder-route comment).
+ * reorder. Failures propagate to the shared serverError middleware (issue
+ * #115) — Express 5 forwards rejected async handlers automatically.
  *
  * @param {object} deps
  * @param {object} deps.prisma
@@ -13,20 +13,18 @@ import express from "express";
 export function createProductsRouter({ prisma, auth, requireAdmin }) {
   const router = express.Router();
 
-  router.get("/products", async (req, res) => {
-    try {
-      const products = await prisma.product.findMany({ orderBy: { sortOrder: "asc" } });
-      res.json(products);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
+  router.get("/products", async function listProducts(req, res) {
+    const products = await prisma.product.findMany({ orderBy: { sortOrder: "asc" } });
+    res.json(products);
   });
 
   // registered before /:id so a future PATCH /products/:id can't shadow it —
   // today nothing else answers PATCH, so behavior is unchanged
-  router.patch("/products/reorder", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.patch(
+    "/products/reorder",
+    auth.requireAuth(),
+    requireAdmin,
+    async function reorderProducts(req, res) {
       const updates = req.body;
       await Promise.all(
         updates.map(({ id, sortOrder }) =>
@@ -34,39 +32,34 @@ export function createProductsRouter({ prisma, auth, requireAdmin }) {
         )
       );
       res.json({ ok: true });
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
+    },
+  );
+
+  router.get("/products/:id", async function getProduct(req, res) {
+    const id = Number(req.params.id);
+    const singleProduct = await prisma.product.findUnique({ where: { id } });
+    if (!singleProduct) return res.status(404).json({ error: "Nie znaleziono produktu" });
+    res.json(singleProduct);
   });
 
-  router.get("/products/:id", async (req, res) => {
-    try {
-      const id = Number(req.params.id);
-      const singleProduct = await prisma.product.findUnique({ where: { id } });
-      if (!singleProduct) return res.status(404).json({ error: "Nie znaleziono produktu" });
-      res.json(singleProduct);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
-
-  router.post("/products", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.post(
+    "/products",
+    auth.requireAuth(),
+    requireAdmin,
+    async function createProduct(req, res) {
       const { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock } = req.body;
       const product = await prisma.product.create({
         data: { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock },
       });
       res.json(product);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+    },
+  );
 
-  router.put("/products/:id", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.put(
+    "/products/:id",
+    auth.requireAuth(),
+    requireAdmin,
+    async function updateProduct(req, res) {
       const { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock } = req.body;
       const id = Number(req.params.id);
       const updated = await prisma.product.update({
@@ -74,22 +67,19 @@ export function createProductsRouter({ prisma, auth, requireAdmin }) {
         data: { name, tagline, description, price, imageUrl, lifestyleImageUrl, stock },
       });
       res.json(updated);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+    },
+  );
 
-  router.delete("/products/:id", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.delete(
+    "/products/:id",
+    auth.requireAuth(),
+    requireAdmin,
+    async function deleteProduct(req, res) {
       const id = Number(req.params.id);
       const deleted = await prisma.product.delete({ where: { id } });
       res.json(deleted);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/backend/routes/revenue.js
+++ b/backend/routes/revenue.js
@@ -3,7 +3,8 @@ import { computeQuarterRevenue } from "../revenue/index.ts";
 
 /**
  * Quarterly DN-revenue route (issue #108): admin dashboard's view of paid
- * revenue vs the registration cap. Handler moved verbatim from app.js.
+ * revenue vs the registration cap. Failures propagate to the shared
+ * serverError middleware (issue #115).
  *
  * @param {object} deps
  * @param {object} deps.prisma
@@ -15,18 +16,18 @@ export function createRevenueRouter({ prisma, auth, requireAdmin }) {
 
   // quarterly DN revenue vs the registration cap — order volume is tiny at DN
   // scale, so fetching all paid orders and filtering in the pure function is fine
-  router.get("/revenue/quarter", auth.requireAuth(), requireAdmin, async (req, res) => {
-    try {
+  router.get(
+    "/revenue/quarter",
+    auth.requireAuth(),
+    requireAdmin,
+    async function getQuarterRevenue(req, res) {
       const paidOrders = await prisma.order.findMany({
         where: { status: "paid" },
         select: { status: true, total: true, createdAt: true },
       });
       res.json(computeQuarterRevenue(paidOrders, new Date()));
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Błąd serwera" });
-    }
-  });
+    },
+  );
 
   return router;
 }

--- a/backend/test/app.smoke.db.test.ts
+++ b/backend/test/app.smoke.db.test.ts
@@ -3,44 +3,22 @@
  * Express app runs over HTTP against the real test database, with fakes
  * injected for auth, Stripe, and mail.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
-let prisma: PrismaClient;
-
-beforeAll(() => {
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-});
+const harness = useAppHarness();
 
 describe("createApp smoke test — GET /products", () => {
   it("serves seeded products over HTTP with all fakes injected", async () => {
-    await prisma.product.createMany({
+    await harness.prisma.product.createMany({
       data: [
         { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 },
         { name: "Rama Jesionowa 21×30", price: 89, stock: 2 },
       ],
     });
 
-    const app = createApp({
-      auth: fakeAuth(),
-      stripe: fakeStripe(),
-      mailer: captureMailer(),
-      prisma,
-    });
-
-    const res = await request(app).get("/products");
+    const res = await request(harness.appAs().app).get("/products");
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);

--- a/backend/test/checkout.db.test.ts
+++ b/backend/test/checkout.db.test.ts
@@ -4,36 +4,15 @@
  * with the outbound Stripe client faked (createdSessions records the params
  * the app would send to Stripe).
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+import { fakeStripe } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
-let prisma: PrismaClient;
-
-beforeAll(() => {
-  process.env.FRONTEND_URL = "https://shop.test";
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-});
+const harness = useAppHarness({ env: { FRONTEND_URL: "https://shop.test" } });
 
 function buildApp({ stripe = fakeStripe() as object }: { stripe?: object | null } = {}) {
-  const app = createApp({
-    auth: fakeAuth(),
-    stripe,
-    mailer: captureMailer(),
-    prisma,
-  });
-  return app;
+  return harness.appAs({}, { stripe }).app;
 }
 
 /** The slice of Stripe session-create params the tests assert on. */
@@ -60,7 +39,7 @@ const shippingAddress = {
 
 describe("POST /create-checkout-session", () => {
   it("creates a server-priced session and returns its url", async () => {
-    await prisma.product.create({
+    await harness.prisma.product.create({
       data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 5, imageUrl: "/ramy/debowa.jpg" },
     });
     const stripe = fakeStripe({ checkoutSessionUrl: "https://stripe.test/pay/cs_1" });
@@ -104,7 +83,7 @@ describe("POST /create-checkout-session", () => {
   });
 
   it("rejects checkout above available stock with 409 and creates no session", async () => {
-    await prisma.product.create({
+    await harness.prisma.product.create({
       data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 1 },
     });
     const stripe = fakeStripe();

--- a/backend/test/forms.db.test.ts
+++ b/backend/test/forms.db.test.ts
@@ -15,8 +15,6 @@ beforeEach(async () => {
   await harness.prisma.contactMessage.deleteMany();
 });
 
-const buildApp = () => harness.appAs();
-
 describe("POST /contact", () => {
   const validBody = {
     name: "Jan Kowalski",
@@ -25,7 +23,7 @@ describe("POST /contact", () => {
   };
 
   it("rejects a submission with missing fields (400)", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app).post("/contact").send({ name: "Jan" });
 
@@ -34,7 +32,7 @@ describe("POST /contact", () => {
   });
 
   it("silently swallows honeypot submissions — no message stored, no email", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app)
       .post("/contact")
@@ -47,7 +45,7 @@ describe("POST /contact", () => {
   });
 
   it("stores the message and notifies the shop with reply-to set to the sender", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app).post("/contact").send(validBody);
 
@@ -71,7 +69,7 @@ describe("POST /zwrot", () => {
   };
 
   it("rejects a submission with missing fields (400)", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app)
       .post("/zwrot")
@@ -82,7 +80,7 @@ describe("POST /zwrot", () => {
   });
 
   it("silently swallows honeypot submissions", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app)
       .post("/zwrot")
@@ -93,7 +91,7 @@ describe("POST /zwrot", () => {
   });
 
   it("emails the return request to the shop", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app).post("/zwrot").send(validBody);
 
@@ -116,7 +114,7 @@ describe("POST /reklamacja", () => {
   };
 
   it("rejects a submission with missing fields (400)", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app).post("/reklamacja").send({ name: "Jan" });
 
@@ -125,7 +123,7 @@ describe("POST /reklamacja", () => {
   });
 
   it("emails the complaint to the shop", async () => {
-    const { app, mailer } = buildApp();
+    const { app, mailer } = harness.appAs();
 
     const res = await request(app).post("/reklamacja").send(validBody);
 

--- a/backend/test/forms.db.test.ts
+++ b/backend/test/forms.db.test.ts
@@ -4,39 +4,18 @@
  * send mail on anonymous input, so the coverage centers on the guardrails —
  * field validation and the honeypot — plus the capture-mailer contract.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
-let prisma: PrismaClient;
+const harness = useAppHarness({ env: { CONTACT_RECIPIENT: "sklep@test.local" } });
 
-beforeAll(() => {
-  process.env.CONTACT_RECIPIENT = "sklep@test.local";
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
+// contact messages aren't commerce state, so the shared truncate skips them
 beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-  await prisma.contactMessage.deleteMany();
+  await harness.prisma.contactMessage.deleteMany();
 });
 
-function buildApp() {
-  const mailer = captureMailer();
-  const app = createApp({
-    auth: fakeAuth(),
-    stripe: fakeStripe(),
-    mailer,
-    prisma,
-  });
-  return { app, mailer };
-}
+const buildApp = () => harness.appAs();
 
 describe("POST /contact", () => {
   const validBody = {
@@ -64,7 +43,7 @@ describe("POST /contact", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
     expect(mailer.sent).toHaveLength(0);
-    expect(await prisma.contactMessage.count()).toBe(0);
+    expect(await harness.prisma.contactMessage.count()).toBe(0);
   });
 
   it("stores the message and notifies the shop with reply-to set to the sender", async () => {

--- a/backend/test/harness.ts
+++ b/backend/test/harness.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared supertest harness for the DB-backed suite (issue #115). One call
+ * per test file replaces the copy-pasted beforeAll/afterAll/beforeEach +
+ * buildApp block: it owns the Prisma client lifecycle, resets commerce
+ * state between cases, and builds apps with the standard fakes injected.
+ */
+import { beforeAll, afterAll, beforeEach } from "vitest";
+import type { PrismaClient } from "../generated/prisma/client.js";
+import { createTestPrisma, truncateCommerceTables } from "./db.ts";
+import { createApp } from "../app.js";
+import { fakeAuth, fakeStripe, captureMailer, type FakeAuthOptions } from "./fakes.ts";
+
+export interface HarnessOptions {
+  /** process.env entries the routes under test read (set in beforeAll). */
+  env?: Record<string, string>;
+}
+
+export interface AppOverrides {
+  /** Replace the default fakeStripe() — e.g. real signature verification, or null for demo mode. */
+  stripe?: object | null;
+}
+
+export function useAppHarness({ env = {} }: HarnessOptions = {}) {
+  let prisma: PrismaClient;
+
+  beforeAll(() => {
+    Object.assign(process.env, env);
+    prisma = createTestPrisma();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await truncateCommerceTables(prisma);
+  });
+
+  /** App impersonating `auth` (default anonymous), with a fresh capture mailer. */
+  function appAs(auth: FakeAuthOptions = {}, overrides: AppOverrides = {}) {
+    const mailer = captureMailer();
+    const app = createApp({
+      auth: fakeAuth(auth),
+      stripe: overrides.stripe === undefined ? fakeStripe() : overrides.stripe,
+      mailer,
+      prisma,
+    });
+    return { app, mailer };
+  }
+
+  return {
+    // prisma exists only after beforeAll — a getter keeps call sites plain
+    // (`harness.prisma`) without capturing the pre-init value.
+    get prisma() {
+      return prisma;
+    },
+    appAs,
+  };
+}

--- a/backend/test/orders.db.test.ts
+++ b/backend/test/orders.db.test.ts
@@ -4,41 +4,15 @@
  * read user B's orders, guest orders stay hidden behind the by-session lookup,
  * and admins bypass ownership for back-office work.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer, type FakeAuthOptions } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
-let prisma: PrismaClient;
+const harness = useAppHarness();
 
-beforeAll(() => {
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-});
-
-function buildApp(authOptions: FakeAuthOptions = {}) {
-  const mailer = captureMailer();
-  const app = createApp({
-    auth: fakeAuth(authOptions),
-    stripe: fakeStripe(),
-    mailer,
-    prisma,
-  });
-  return { app, mailer };
-}
-
-const anonymous = () => buildApp().app;
-const asUser = (userId: string) => buildApp({ userId }).app;
-const admin = () => buildApp({ userId: "user_admin", role: "admin" });
+const anonymous = () => harness.appAs().app;
+const asUser = (userId: string) => harness.appAs({ userId }).app;
+const admin = () => harness.appAs({ userId: "user_admin", role: "admin" });
 
 /** Paid order with one line item, owned by `userId` (null = guest). */
 async function seedOrder({
@@ -52,10 +26,10 @@ async function seedOrder({
   total?: number;
   customerEmail?: string | null;
 }) {
-  const product = await prisma.product.create({
+  const product = await harness.prisma.product.create({
     data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 },
   });
-  return prisma.order.create({
+  return harness.prisma.order.create({
     data: {
       stripeSessionId: sessionId,
       status: "paid",

--- a/backend/test/products.db.test.ts
+++ b/backend/test/products.db.test.ts
@@ -4,45 +4,21 @@
  * boundary — every mutating route rejects anonymous (401) and signed-in
  * non-admin (403) callers before touching the database.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer, type FakeAuthOptions } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
-let prisma: PrismaClient;
+const harness = useAppHarness();
 
-beforeAll(() => {
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-});
-
-function buildApp(authOptions: FakeAuthOptions = {}) {
-  return createApp({
-    auth: fakeAuth(authOptions),
-    stripe: fakeStripe(),
-    mailer: captureMailer(),
-    prisma,
-  });
-}
-
-const anonymous = () => buildApp();
-const nonAdmin = () => buildApp({ userId: "user_regular" });
-const admin = () => buildApp({ userId: "user_admin", role: "admin" });
+const anonymous = () => harness.appAs().app;
+const nonAdmin = () => harness.appAs({ userId: "user_regular" }).app;
+const admin = () => harness.appAs({ userId: "user_admin", role: "admin" }).app;
 
 const frameData = { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 };
 
 describe("GET /products/:id", () => {
   it("returns the product publicly", async () => {
-    await prisma.product.create({ data: frameData });
+    await harness.prisma.product.create({ data: frameData });
 
     const res = await request(anonymous()).get("/products/1");
 
@@ -86,7 +62,7 @@ describe("POST /products — admin boundary", () => {
 
 describe("PUT /products/:id — admin boundary", () => {
   beforeEach(async () => {
-    await prisma.product.create({ data: frameData });
+    await harness.prisma.product.create({ data: frameData });
   });
 
   it("rejects anonymous callers with 401", async () => {
@@ -113,7 +89,7 @@ describe("PUT /products/:id — admin boundary", () => {
 
 describe("DELETE /products/:id — admin boundary", () => {
   beforeEach(async () => {
-    await prisma.product.create({ data: frameData });
+    await harness.prisma.product.create({ data: frameData });
   });
 
   it("rejects anonymous callers with 401", async () => {
@@ -140,7 +116,7 @@ describe("DELETE /products/:id — admin boundary", () => {
 
 describe("PATCH /products/reorder — admin boundary", () => {
   beforeEach(async () => {
-    await prisma.product.createMany({
+    await harness.prisma.product.createMany({
       data: [
         { name: "Rama A", price: 100, sortOrder: 0 },
         { name: "Rama B", price: 120, sortOrder: 1 },

--- a/backend/test/revenue.db.test.ts
+++ b/backend/test/revenue.db.test.ts
@@ -4,52 +4,30 @@
  * computeQuarterRevenue — here we cover the admin boundary and that only
  * paid orders reach the sum.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import request from "supertest";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer, type FakeAuthOptions } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 import { QUARTERLY_REVENUE_CAP_PLN } from "../revenue/index.ts";
 
-let prisma: PrismaClient;
-
-beforeAll(() => {
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
-});
-
-function buildApp(authOptions: FakeAuthOptions = {}) {
-  return createApp({
-    auth: fakeAuth(authOptions),
-    stripe: fakeStripe(),
-    mailer: captureMailer(),
-    prisma,
-  });
-}
+const harness = useAppHarness();
 
 describe("GET /revenue/quarter", () => {
   it("rejects anonymous callers with 401", async () => {
-    const res = await request(buildApp()).get("/revenue/quarter");
+    const res = await request(harness.appAs().app).get("/revenue/quarter");
 
     expect(res.status).toBe(401);
   });
 
   it("rejects signed-in non-admins with 403", async () => {
-    const res = await request(buildApp({ userId: "user_regular" })).get("/revenue/quarter");
+    const res = await request(harness.appAs({ userId: "user_regular" }).app).get(
+      "/revenue/quarter",
+    );
 
     expect(res.status).toBe(403);
   });
 
   it("sums paid orders for the current quarter, excluding pending ones", async () => {
-    await prisma.order.createMany({
+    await harness.prisma.order.createMany({
       data: [
         { stripeSessionId: "cs_paid_1", status: "paid", total: 149.99 },
         { stripeSessionId: "cs_paid_2", status: "paid", total: 89.0 },
@@ -57,7 +35,7 @@ describe("GET /revenue/quarter", () => {
       ],
     });
 
-    const res = await request(buildApp({ userId: "user_admin", role: "admin" })).get(
+    const res = await request(harness.appAs({ userId: "user_admin", role: "admin" }).app).get(
       "/revenue/quarter",
     );
 

--- a/backend/test/webhook.db.test.ts
+++ b/backend/test/webhook.db.test.ts
@@ -7,13 +7,12 @@
  * with `generateTestHeaderString` + a test secret. Only outbound Stripe
  * calls (listLineItems, paymentIntents) are faked.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import request from "supertest";
 import Stripe from "stripe";
-import type { PrismaClient } from "../generated/prisma/client.js";
-import { createTestPrisma, truncateCommerceTables } from "./db.ts";
-import { createApp } from "../app.js";
-import { fakeAuth, fakeStripe, captureMailer } from "./fakes.ts";
+import type { createApp } from "../app.js";
+import { fakeStripe } from "./fakes.ts";
+import { useAppHarness } from "./harness.ts";
 
 const TEST_WEBHOOK_SECRET = "whsec_test_integration_secret";
 const ADMIN_RECIPIENT = "admin@test.local";
@@ -22,20 +21,11 @@ const ADMIN_RECIPIENT = "admin@test.local";
 // offline crypto; the API key is never used.
 const signatureKit = new Stripe("sk_test_offline_signature_only");
 
-let prisma: PrismaClient;
-
-beforeAll(() => {
-  process.env.STRIPE_WEBHOOK_SECRET = TEST_WEBHOOK_SECRET;
-  process.env.CONTACT_RECIPIENT = ADMIN_RECIPIENT;
-  prisma = createTestPrisma();
-});
-
-afterAll(async () => {
-  await prisma.$disconnect();
-});
-
-beforeEach(async () => {
-  await truncateCommerceTables(prisma);
+const harness = useAppHarness({
+  env: {
+    STRIPE_WEBHOOK_SECRET: TEST_WEBHOOK_SECRET,
+    CONTACT_RECIPIENT: ADMIN_RECIPIENT,
+  },
 });
 
 /** Stripe line item as listLineItems returns it (price.product expanded). */
@@ -91,15 +81,13 @@ function signedPost(
 }
 
 function buildApp({ lineItems = [] as unknown[] } = {}) {
-  const mailer = captureMailer();
   const stripe = {
     ...fakeStripe({ lineItems }),
     // Real verification path — a forged or tampered payload must be
     // rejected by the same code that runs in production.
     webhooks: signatureKit.webhooks,
   };
-  const app = createApp({ auth: fakeAuth(), stripe, mailer, prisma });
-  return { app, mailer };
+  return harness.appAs({}, { stripe });
 }
 
 describe("POST /webhook — checkout.session.completed", () => {
@@ -129,7 +117,7 @@ describe("POST /webhook — checkout.session.completed", () => {
   ];
 
   async function seedProduct() {
-    await prisma.product.create({
+    await harness.prisma.product.create({
       data: { name: "Rama Dębowa 30×40", price: 149.99, stock: 5 },
     });
   }
@@ -224,7 +212,7 @@ describe("POST /webhook — checkout.session.completed", () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
 
-    const orders = await prisma.order.findMany({
+    const orders = await harness.prisma.order.findMany({
       where: { stripeSessionId: "cs_test_paid_1" },
     });
     expect(orders).toHaveLength(1);

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,7 +5,12 @@ import { defineConfig } from "vitest/config";
 // *.db.test.ts files need Postgres and run separately via `npm run test:db`.
 export default defineConfig({
   test: {
-    include: ["emails/**/*.test.ts", "orders/**/*.test.ts", "revenue/**/*.test.ts"],
+    include: [
+      "emails/**/*.test.ts",
+      "middleware/**/*.test.ts",
+      "orders/**/*.test.ts",
+      "revenue/**/*.test.ts",
+    ],
     exclude: ["**/*.db.test.ts", "**/node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
- `middleware/errors.js`: one `serverError` tail handler replaces the 13 copy-pasted `catch → console.error → 500 Błąd serwera` blocks in `routes/*.js`. Express 5 auto-forwards rejected async handlers, so no `asyncHandler` wrapper was needed. Every touched handler gained a name (stack traces, per code style).
- Intentional survivors (behavior differs, documented in each router's doc comment): webhook's 400-signature/500-retry catches, zwrot/reklamacja's fallback-address 500 body, checkout's `email_invalid → 400` mapping (which now rethrows everything else).
- `test/harness.ts`: `useAppHarness()` owns the Prisma lifecycle, per-case truncation, env setup, and `appAs()` app construction; all 8 `*.db.test.ts` suites migrated, assertions unchanged.
- `productInput()` picker for the POST/PUT products field clump (the optional item).

## Notes for review
- The acceptance box "no per-route try/catch 500 boilerplate" is met for the *boilerplate* pattern; the catches listed above stay because migrating them would violate "keep behavior identical".
- One deliberate behavioral addition: `serverError` guards `res.headersSent` (mid-stream failures delegate to Express's default handler instead of a double-send crash).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` 66/66 (includes 3 new tests for the middleware via `createApp` with a stub prisma)
- [x] `npm run test:db` 59/59, assertions unchanged
- [x] Two-axis code review (standards + spec) run; findings fixed in 1b470a1

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)