### PR TITLE
fix: scope React lint rules to the frontend

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,14 +9,18 @@ export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
     languageOptions: {
       ecmaVersion: 2020,
+    },
+  },
+  // React-specific rules only apply to the frontend — rules-of-hooks treats
+  // any use* function as a React Hook, which misfires on backend helpers
+  // (e.g. test/harness.ts useAppHarness).
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [reactHooks.configs.flat.recommended, reactRefresh.configs.vite],
+    languageOptions: {
       globals: globals.browser,
     },
   },


### PR DESCRIPTION
## Summary
- CI on `main` went red after #119 ([run 29408722790](https://github.com/adrian-imiolo/shop_sznyt_design/actions/runs/29408722790)): `react-hooks/rules-of-hooks` flagged the new backend test helper `useAppHarness` as a React Hook called at top level — 7 lint errors, all in `backend/test/*.db.test.ts`.
- Root cause is the ESLint config, not the helper: `reactHooks` + `reactRefresh` + browser globals were applied to **all** `**/*.{ts,tsx}`, backend included. Any `use*`-named function outside React would trip it.
- Fix scopes the React plugins and browser globals to `src/**`; `js` + `typescript-eslint` recommended still lint the whole repo.

## Test plan
- [x] `npm run lint` clean locally
- [x] `eslint --print-config backend/test/harness.ts` → no react-hooks rules
- [x] `eslint --print-config src/App.tsx` → `react-hooks/rules-of-hooks` still active

🤖 Generated with [Claude Code](https://claude.com/claude-code)