### PR TITLE
fix: never crop the frame out of product imagery

### DIFF
--- a/src/components/ProductSection.tsx
+++ b/src/components/ProductSection.tsx
@@ -46,7 +46,7 @@ function ProductSection({
         <Link
           to={`/sklep/${id}`}
           aria-label={`Zobacz produkt: ${name}`}
-          className="relative w-full md:w-1/2 min-h-[60vh] lg:min-h-screen overflow-hidden cursor-pointer"
+          className="relative w-full md:w-1/2 aspect-[4/5] overflow-hidden cursor-pointer"
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -83,13 +83,12 @@ function ProductDetails() {
         onMouseLeave={() => setHovered(false)}
       >
         <div
-          className={`absolute inset-6 md:inset-10 bg-cover bg-center transition-opacity duration-700 ${hovered ? "opacity-0" : "opacity-100"}`}
+          className={`absolute inset-6 md:inset-10 bg-contain bg-center bg-no-repeat transition-opacity duration-700 ${hovered ? "opacity-0" : "opacity-100"}`}
           style={{ backgroundImage: `url(${product.imageUrl})` }}
         />
-        {/* Lifestyle frame sits high in the scene, so bias the crop upward */}
         <div
-          className={`absolute inset-6 md:inset-10 bg-cover transition-opacity duration-700 ${hovered ? "opacity-100" : "opacity-0"}`}
-          style={{ backgroundImage: `url(${product.lifestyleImageUrl})`, backgroundPosition: "center 15%" }}
+          className={`absolute inset-6 md:inset-10 bg-contain bg-center bg-no-repeat transition-opacity duration-700 ${hovered ? "opacity-100" : "opacity-0"}`}
+          style={{ backgroundImage: `url(${product.lifestyleImageUrl})` }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
Follow-up to #121: the tighter studio crops exposed that `bg-cover` in containers that aren't 4:5 zooms into the frame itself.

- Home `ProductSection`: image panel locked to `aspect-[4/5]` — matches the image ratio, so `cover` shows the full frame at every viewport
- `ProductDetail`: image layers switched to `bg-contain bg-center` — whole frame always visible regardless of panel ratio
- Shop grid needed no change (cards were already `aspect-[4/5]`)

Verified in a live browser (desktop 1600px + mobile 390px) against the deployed backend: home, `/sklep`, `/sklep/1` all show the complete frame.

## Test plan
- [x] Home, shop, and product page show the whole frame on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)