### PR TITLE
fix: full-viewport sections account for sticky navbar height

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 function Hero() {
   return (
-    <section className="relative min-h-[60vh] md:min-h-screen flex items-end bg-near-black">
+    <section className="relative min-h-[60vh] md:min-h-[calc(100vh-var(--spacing-nav))] flex items-end bg-near-black">
       {/* AI render (#78) — replaced by real photography in #11 */}
       <div className="absolute inset-0 bg-[#2a2420] bg-cover bg-center bg-[url(/images/hero.webp)]" />
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -21,8 +21,8 @@ function Navbar() {
   }, []);
 
   return (
-    <nav className={`sticky top-0 z-40 bg-warm-white border-b border-borders px-6 py-4 transition-shadow duration-300 ${scrolled ? "shadow-sm" : ""}`}>
-      <div className="flex items-center justify-between max-w-6xl mx-auto">
+    <nav className={`sticky top-0 z-40 bg-warm-white border-b border-borders px-6 py-4 md:py-0 md:h-nav transition-shadow duration-300 ${scrolled ? "shadow-sm" : ""}`}>
+      <div className="flex items-center justify-between max-w-6xl mx-auto md:h-full">
         <Link
           to="/"
           className="font-cormorant text-xl md:text-2xl text-near-black tracking-wide whitespace-nowrap"

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,10 @@
   --font-serif: "Cormorant Garamond", Georgia, serif;
   --font-sans: "DM Sans", sans-serif;
 
+  /* Sticky navbar height (md+). Full-viewport sections use
+     calc(100vh - var(--spacing-nav)) so the fold lands exactly at their bottom edge. */
+  --spacing-nav: 4rem;
+
 }
 
 body {

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -36,7 +36,7 @@ function ProductDetails() {
     );
   if (!product)
     return (
-      <main className="flex flex-col md:flex-row lg:h-screen lg:max-h-240">
+      <main className="flex flex-col md:flex-row lg:h-[calc(100vh-var(--spacing-nav))] lg:max-h-240">
         <Seo
           title="Produkt"
           description="Ręcznie robiona ramka z litego dębu od Sznyt Design. Designerski prezent, który zostaje na lata."
@@ -63,7 +63,7 @@ function ProductDetails() {
     );
 
   return (
-    <main className="flex flex-col md:flex-row lg:h-screen lg:max-h-240">
+    <main className="flex flex-col md:flex-row lg:h-[calc(100vh-var(--spacing-nav))] lg:max-h-240">
       <Seo
         title={product.name}
         description={`${product.tagline} Ręcznie robiona ramka z litego dębu od Sznyt Design — designerski prezent, który zostaje na lata.`}


### PR DESCRIPTION
## Summary
- New `--spacing-nav` theme token (4rem) — single source of truth for navbar height
- Navbar pinned to `h-nav` on md+ (mobile keeps auto height for the burger dropdown)
- Hero and ProductDetail (incl. skeleton) fill `calc(100vh - var(--spacing-nav))` instead of `h-screen`, so the whole frame + price/CTA land inside the first viewport on laptops

## Test plan
- [x] lint, typecheck, build green
- [ ] `/sklep/1` on a laptop viewport: full frame visible without scrolling
- [ ] Homepage hero: CTA + scroll arrow not cut off
- [ ] Mobile: burger menu still expands below the navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)