### PR TITLE
fix: home product sections and shop cards fit a laptop viewport

### DIFF
--- a/src/components/ProductSection.tsx
+++ b/src/components/ProductSection.tsx
@@ -40,24 +40,25 @@ function ProductSection({
       </div>
 
       <section
-        className={`flex flex-col ${reverse ? "md:flex-row-reverse" : "md:flex-row"} lg:min-h-screen`}
+        className={`flex flex-col ${reverse ? "md:flex-row-reverse" : "md:flex-row"} lg:h-[calc(100vh-var(--spacing-nav))] lg:max-h-240`}
       >
-        {/* Image side */}
+        {/* Image side — 4:5 cover crop up to md; on lg the section is viewport-height,
+            so the whole frame must fit: contain inside a padded panel instead */}
         <Link
           to={`/sklep/${id}`}
           aria-label={`Zobacz produkt: ${name}`}
-          className="relative w-full md:w-1/2 aspect-[4/5] overflow-hidden cursor-pointer"
+          className="relative w-full md:w-1/2 aspect-[4/5] lg:aspect-auto lg:h-full overflow-hidden cursor-pointer bg-warm-white"
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
           {/* Studio image — visible by default */}
           <div
-            className={`absolute inset-0 bg-cover bg-center transition-opacity duration-700 ${hovered ? "opacity-0" : "opacity-100"}`}
+            className={`absolute inset-0 lg:inset-10 bg-cover lg:bg-contain bg-center bg-no-repeat transition-opacity duration-700 ${hovered ? "opacity-0" : "opacity-100"}`}
             style={{ backgroundImage: `url(${imageUrl})` }}
           />
           {/* Lifestyle image — visible on hover; frame sits high in the scene, so bias the crop upward */}
           <div
-            className={`absolute inset-0 bg-cover transition-opacity duration-700 ${hovered ? "opacity-100" : "opacity-0"}`}
+            className={`absolute inset-0 lg:inset-10 bg-cover lg:bg-contain bg-no-repeat transition-opacity duration-700 ${hovered ? "opacity-100" : "opacity-0"}`}
             style={{ backgroundImage: `url(${lifestyleImageUrl})`, backgroundPosition: "center 15%" }}
           />
         </Link>

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -87,7 +87,8 @@ function Shop() {
 
       {/* Product grid */}
       <section className="bg-warm-white px-6 py-8 md:py-16">
-        <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-10">
+        {/* max-w-4xl (not 6xl): keeps a 4:5 card + title inside one laptop viewport */}
+        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-10">
           {error ? (
             <p className="font-dm-sans text-sm text-red-600 col-span-2">{error}</p>
           ) : (


### PR DESCRIPTION
## Summary
- Home `ProductSection`: on lg the section is `calc(100vh - nav)` tall and the image switches to `bg-contain` in a padded panel (same pattern as ProductDetail); up to md keeps the 4:5 cover crop
- Shop grid: `max-w-6xl` → `max-w-4xl` so a 4:5 card plus title/price fits one laptop viewport

## Test plan
- [x] lint + typecheck + build green
- [x] Verified at 1522×672 (Adrian''s laptop viewport) on dev server: whole frame visible on home section and shop cards
- [ ] Sanity-check mobile + tablet (unchanged behavior expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)