### PR TITLE
refactor: admin-role rule moves to @sznyt/shared

### DIFF
--- a/backend/middleware/adminAuth.js
+++ b/backend/middleware/adminAuth.js
@@ -6,6 +6,8 @@
  * @param {{ getAuth: Function }} auth
  * @returns {{ getRole: Function, requireAdmin: Function }}
  */
+import { isAdminRole } from "@sznyt/shared";
+
 export function createAdminAuth(auth) {
   function getRole(req) {
     const { sessionClaims } = auth.getAuth(req);
@@ -13,7 +15,7 @@ export function createAdminAuth(auth) {
   }
 
   function requireAdmin(req, res, next) {
-    if (getRole(req) !== "admin") {
+    if (!isAdminRole(getRole(req))) {
       return res.status(403).json({ error: "Forbidden" });
     }
     next();

--- a/backend/middleware/adminAuth.js
+++ b/backend/middleware/adminAuth.js
@@ -1,3 +1,5 @@
+import { isAdminRole } from "@sznyt/shared";
+
 /**
  * Admin gate shared by the back-office routes (issue #108). The role lives
  * in Clerk session claims (metadata.role); built from the injected auth seam
@@ -6,8 +8,6 @@
  * @param {{ getAuth: Function }} auth
  * @returns {{ getRole: Function, requireAdmin: Function }}
  */
-import { isAdminRole } from "@sznyt/shared";
-
 export function createAdminAuth(auth) {
   function getRole(req) {
     const { sessionClaims } = auth.getAuth(req);

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { renderOrderShipped } from "../emails/index.ts";
-import { FULFILLMENT_STATUSES } from "@sznyt/shared";
+import { FULFILLMENT_STATUSES, isAdminRole } from "@sznyt/shared";
 
 /**
  * Orders routes (issue #108): admin list + fulfillment, per-user orders,
@@ -103,7 +103,7 @@ export function createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole
     // sequential ids must not expose their shipping data to other signed-in users.
     // Admins bypass the ownership check: the admin order-detail page reads any
     // order (guest ones included) through this endpoint.
-    if (order.userId !== auth.getAuth(req).userId && getRole(req) !== "admin") {
+    if (order.userId !== auth.getAuth(req).userId && !isAdminRole(getRole(req))) {
       return res.status(403).json({ error: "Forbidden" });
     }
     res.json(order);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,5 +20,6 @@ export type { ShippingMethod } from "./shipping.ts";
 export type { ShippingAddress } from "./shippingAddress.ts";
 export { ORDER_NOTE_MAX_LENGTH } from "./orderNote.ts";
 export { formatPln } from "./money.ts";
+export { ADMIN_ROLE, isAdminRole } from "./roles.ts";
 export { REVENUE_THRESHOLDS } from "./revenue.ts";
 export type { QuarterRevenue, QuarterRevenueThreshold } from "./revenue.ts";

--- a/packages/shared/src/roles.test.ts
+++ b/packages/shared/src/roles.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { ADMIN_ROLE, isAdminRole } from "./roles.ts";
+
+describe("isAdminRole", () => {
+  it("accepts the canonical admin role value", () => {
+    expect(isAdminRole(ADMIN_ROLE)).toBe(true);
+    expect(isAdminRole("admin")).toBe(true);
+  });
+
+  it("rejects other roles and non-string claims", () => {
+    expect(isAdminRole("user")).toBe(false);
+    expect(isAdminRole("Admin")).toBe(false);
+    expect(isAdminRole("")).toBe(false);
+    expect(isAdminRole(null)).toBe(false);
+    expect(isAdminRole(undefined)).toBe(false);
+    expect(isAdminRole(0)).toBe(false);
+    expect(isAdminRole({ role: "admin" })).toBe(false);
+  });
+});

--- a/packages/shared/src/roles.ts
+++ b/packages/shared/src/roles.ts
@@ -1,0 +1,11 @@
+/**
+ * The admin-role rule (issue #129): which claim value grants back-office
+ * access. Clerk surfaces the role differently on each side (publicMetadata
+ * in the browser, session claims on the server) — extraction stays in the
+ * adapters, but the rule itself lives only here.
+ */
+export const ADMIN_ROLE = "admin";
+
+export function isAdminRole(role: unknown): boolean {
+  return role === ADMIN_ROLE;
+}

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,7 +1,8 @@
 import { useUser } from "@clerk/react";
+import { isAdminRole } from "@sznyt/shared";
 
 export function useIsAdmin(): { isAdmin: boolean; isLoaded: boolean } {
   const { user, isLoaded } = useUser();
-  const isAdmin = user?.publicMetadata?.role === "admin";
+  const isAdmin = isAdminRole(user?.publicMetadata?.role);
   return { isAdmin, isLoaded };
 }


### PR DESCRIPTION
## Summary
- New `packages/shared/src/roles.ts`: `ADMIN_ROLE` constant + `isAdminRole(role: unknown)` predicate, exported from the package index, with a unit test (canonical value, other roles, case variant, non-string claims).
- `useIsAdmin` (frontend) and `createAdminAuth` (backend) now delegate to the shared predicate; each keeps extracting the claim from its own Clerk surface.
- The ownership check in `backend/routes/orders.js` also delegates — required so the `"admin"` literal survives only in the shared package (acceptance criterion 4).
- Backend test fixtures keep their literals, unchanged per criterion 5.

## Test plan
- [x] `packages/shared/src/roles.test.ts` — 2/2 (written red-first)
- [x] Backend db suite (admin routes, injected fake auth) — 59/59, test files untouched
- [x] Backend unit suite 66/66, frontend suite 182/182
- [x] `tsc -b` (root) and `tsc --noEmit` (backend) clean, eslint clean
- [x] Two-axis /code-review: spec fully compliant; one standards finding (JSDoc detached by import placement) fixed in follow-up commit

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)