### PR TITLE
refactor: notifyOrderShipped moves into order intake (#130)

### DIFF
--- a/backend/orders/index.ts
+++ b/backend/orders/index.ts
@@ -3,6 +3,8 @@ export { paidOrderFactsFromSession } from "./stripeFacts.ts";
 export { normalizeOrderNote } from "./orderNote.ts";
 export { recordPaidOrder } from "./recordPaidOrder.ts";
 export { notifyOrderPlaced } from "./notifyOrderPlaced.ts";
+export { notifyOrderShipped } from "./notifyOrderShipped.ts";
+export type { ShippedOrderData } from "./notifyOrderShipped.ts";
 export type { PaidOrderFacts, PaidLineItem, CheckoutProduct, CartItemInput } from "./types.ts";
 export type { BuildCheckoutResult } from "./buildCheckoutLineItems.ts";
 export type { RecordPaidOrderResult } from "./recordPaidOrder.ts";

--- a/backend/orders/notifyOrderShipped.test.ts
+++ b/backend/orders/notifyOrderShipped.test.ts
@@ -48,7 +48,7 @@ describe("notifyOrderShipped", () => {
     },
   );
 
-  it.each(["pending", "processing", "delivered"])(
+  it.each(["received", "processing", "delivered"])(
     "sends nothing when the fulfillment status is %s",
     async (fulfillmentStatus) => {
       const mailer = fakeMailer();

--- a/backend/orders/notifyOrderShipped.test.ts
+++ b/backend/orders/notifyOrderShipped.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { notifyOrderShipped } from "./notifyOrderShipped.ts";
+import type { ShippedOrderData } from "./notifyOrderShipped.ts";
+import type { SendEmailOptions } from "../emails/index.ts";
+
+function fakeMailer() {
+  const sent: SendEmailOptions[] = [];
+  return {
+    sent,
+    async send(options: SendEmailOptions) {
+      sent.push(options);
+    },
+  };
+}
+
+function shippedOrder(overrides: Partial<ShippedOrderData> = {}): ShippedOrderData {
+  return {
+    id: 13,
+    fulfillmentStatus: "shipped",
+    customerEmail: "kupujacy@example.com",
+    shippingMethod: "paczkomat",
+    ...overrides,
+  };
+}
+
+describe("notifyOrderShipped", () => {
+  it("emails the customer when shipped with email and tracking number", async () => {
+    const mailer = fakeMailer();
+
+    await notifyOrderShipped(mailer, shippedOrder(), "DPD123456");
+
+    expect(mailer.sent).toHaveLength(1);
+    expect(mailer.sent[0].to).toBe("kupujacy@example.com");
+    expect(mailer.sent[0].subject).toContain("wysłane");
+    expect(mailer.sent[0].html).toContain("#13");
+    expect(mailer.sent[0].html).toContain("DPD123456");
+    expect(mailer.sent[0].html).toContain("InPost Paczkomat");
+  });
+
+  it.each([null, undefined, ""])(
+    "sends nothing when the tracking number is %s",
+    async (trackingNumber) => {
+      const mailer = fakeMailer();
+
+      await notifyOrderShipped(mailer, shippedOrder(), trackingNumber);
+
+      expect(mailer.sent).toHaveLength(0);
+    },
+  );
+
+  it.each(["pending", "processing", "delivered"])(
+    "sends nothing when the fulfillment status is %s",
+    async (fulfillmentStatus) => {
+      const mailer = fakeMailer();
+
+      await notifyOrderShipped(mailer, shippedOrder({ fulfillmentStatus }), "DPD123456");
+
+      expect(mailer.sent).toHaveLength(0);
+    },
+  );
+
+  it("sends nothing when the order has no customer email", async () => {
+    const mailer = fakeMailer();
+
+    await notifyOrderShipped(mailer, shippedOrder({ customerEmail: null }), "DPD123456");
+
+    expect(mailer.sent).toHaveLength(0);
+  });
+
+  it("swallows a send failure instead of throwing", async () => {
+    const failingMailer = {
+      async send() {
+        throw new Error("SMTP down");
+      },
+    };
+
+    await expect(
+      notifyOrderShipped(failingMailer, shippedOrder(), "DPD123456"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/orders/notifyOrderShipped.ts
+++ b/backend/orders/notifyOrderShipped.ts
@@ -1,0 +1,37 @@
+import { renderOrderShipped } from "../emails/index.ts";
+import type { Mailer } from "../emails/index.ts";
+
+/** The slice of a persisted order the shipped notification needs. */
+export interface ShippedOrderData {
+  id: number;
+  fulfillmentStatus: string;
+  customerEmail: string | null;
+  shippingMethod: string | null;
+}
+
+/**
+ * Best-effort shipping notification (issue #130): emails the customer iff the
+ * order is `shipped` AND has a customer email AND a tracking number. Send
+ * failures are swallowed — a recorded fulfillment update must never fail
+ * because of mail problems, so this function never throws.
+ */
+export async function notifyOrderShipped(
+  mailer: Mailer,
+  order: ShippedOrderData,
+  trackingNumber: string | null | undefined,
+): Promise<void> {
+  if (order.fulfillmentStatus !== "shipped" || !order.customerEmail || !trackingNumber) return;
+
+  try {
+    await mailer.send({
+      to: order.customerEmail,
+      ...renderOrderShipped({
+        orderId: order.id,
+        trackingNumber,
+        shippingMethod: order.shippingMethod,
+      }),
+    });
+  } catch (emailErr) {
+    console.error("Błąd wysyłania emaila o wysyłce:", (emailErr as Error).message);
+  }
+}

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { renderOrderShipped } from "../emails/index.ts";
+import { notifyOrderShipped } from "../orders/index.ts";
 import { FULFILLMENT_STATUSES, isAdminRole } from "@sznyt/shared";
 
 /**
@@ -45,21 +45,8 @@ export function createOrdersRouter({ prisma, auth, mailer, requireAdmin, getRole
         data: { fulfillmentStatus, trackingNumber: trackingNumber || null },
       });
 
-      // send shipping email when status set to shipped and we have customer email + tracking number
-      if (fulfillmentStatus === "shipped" && order.customerEmail && trackingNumber) {
-        try {
-          await mailer.send({
-            to: order.customerEmail,
-            ...renderOrderShipped({
-              orderId: order.id,
-              trackingNumber,
-              shippingMethod: order.shippingMethod,
-            }),
-          });
-        } catch (emailErr) {
-          console.error("Błąd wysyłania emaila o wysyłce:", emailErr.message);
-        }
-      }
+      // whether/when to email lives in order intake (issue #130)
+      await notifyOrderShipped(mailer, order, trackingNumber);
 
       res.json(order);
     },


### PR DESCRIPTION
## Summary
- `notifyOrderShipped(mailer, order, trackingNumber)` joins the order intake module, mirroring `notifyOrderPlaced`: plain persisted-order data, injected mailer, full trigger rule inside (sends iff status `shipped` + customer email + tracking number), send failures swallowed
- 9 infra-free unit tests with a fake mailer cover every trigger branch (send, missing email, `null`/`undefined`/`""` tracking, each non-shipped status, send failure)
- The fulfillment route is now a thin adapter: persist, then delegate; DB-backed integration tests untouched

## Test plan
- [x] `npm test` (backend) — 75 passed, incl. 9 new
- [x] `npm run test:db` — 59 passed, fulfillment integration tests unchanged
- [x] `npm run typecheck` — clean

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)