### PR TITLE
test: render tests for the three public-form email templates

### DIFF
--- a/backend/emails/renderComplaintRequest.test.ts
+++ b/backend/emails/renderComplaintRequest.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { renderComplaintRequest } from "./renderComplaintRequest.ts";
+import type { ComplaintRequestData } from "./renderComplaintRequest.ts";
 
-const sampleData = {
+const sampleData: ComplaintRequestData = {
   orderNumber: "42",
   name: "Anna Nowak",
   email: "anna@example.com",

--- a/backend/emails/renderComplaintRequest.test.ts
+++ b/backend/emails/renderComplaintRequest.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderComplaintRequest } from "./renderComplaintRequest.ts";
+
+const sampleData = {
+  orderNumber: "42",
+  name: "Anna Nowak",
+  email: "anna@example.com",
+  description: "Ramka przyszła z pękniętym szkłem.\nProszę o wymianę.",
+};
+
+describe("renderComplaintRequest", () => {
+  const { subject, html, text } = renderComplaintRequest(sampleData);
+
+  it("returns the { subject, html, text } shape", () => {
+    expect(typeof subject).toBe("string");
+    expect(typeof html).toBe("string");
+    expect(typeof text).toBe("string");
+  });
+
+  it("pins the subject", () => {
+    expect(subject).toBe("Reklamacja — zamówienie #42");
+  });
+
+  it.each(["html", "text"] as const)("includes the form data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("#42");
+    expect(output).toContain("Anna Nowak");
+    expect(output).toContain("anna@example.com");
+    expect(output).toContain("Ramka przyszła z pękniętym szkłem.");
+  });
+
+  it.each(["html", "text"] as const)("mentions the photo follow-up in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("przesłanie zdjęć");
+  });
+
+  it("preserves description line breaks in html", () => {
+    expect(html).toContain("szkłem.<br>Proszę o wymianę.");
+  });
+
+  it("escapes an HTML-injection attempt in every user-controlled field", () => {
+    const { html: injectedHtml } = renderComplaintRequest({
+      orderNumber: '<img src=x onerror=alert("order")>',
+      name: "<script>alert('name')</script>",
+      email: "<b>email</b>@example.com",
+      description: "<i>description</i> & more",
+    });
+    expect(injectedHtml).not.toContain("<img");
+    expect(injectedHtml).not.toContain("<script");
+    expect(injectedHtml).not.toContain("<b>email</b>");
+    expect(injectedHtml).not.toContain("<i>description</i>");
+    expect(injectedHtml).toContain("&lt;img src=x onerror=alert(&quot;order&quot;)&gt;");
+    expect(injectedHtml).toContain("&lt;script&gt;alert(&#39;name&#39;)&lt;/script&gt;");
+    expect(injectedHtml).toContain("&lt;b&gt;email&lt;/b&gt;@example.com");
+    expect(injectedHtml).toContain("&lt;i&gt;description&lt;/i&gt; &amp; more");
+  });
+});

--- a/backend/emails/renderContactNotification.test.ts
+++ b/backend/emails/renderContactNotification.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { renderContactNotification } from "./renderContactNotification.ts";
+
+const sampleData = {
+  name: "Jan Kowalski",
+  email: "jan@example.com",
+  message: "Czy ramka 30×40 jest dostępna w orzechu?\nPozdrawiam",
+};
+
+describe("renderContactNotification", () => {
+  const { subject, html, text } = renderContactNotification(sampleData);
+
+  it("returns the { subject, html, text } shape", () => {
+    expect(typeof subject).toBe("string");
+    expect(typeof html).toBe("string");
+    expect(typeof text).toBe("string");
+  });
+
+  it("pins the subject", () => {
+    expect(subject).toBe("Wiadomość od Jan Kowalski — formularz kontaktowy");
+  });
+
+  it.each(["html", "text"] as const)("includes the form data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("Jan Kowalski");
+    expect(output).toContain("jan@example.com");
+    expect(output).toContain("Czy ramka 30×40 jest dostępna w orzechu?");
+  });
+
+  it("preserves message line breaks in html", () => {
+    expect(html).toContain("orzechu?<br>Pozdrawiam");
+  });
+
+  it("escapes an HTML-injection attempt in every user-controlled field", () => {
+    const { html: injectedHtml } = renderContactNotification({
+      name: '<img src=x onerror=alert("name")>',
+      email: "<script>alert('email')</script>@example.com",
+      message: "<b>message</b> & <i>more</i>",
+    });
+    expect(injectedHtml).not.toContain("<img");
+    expect(injectedHtml).not.toContain("<script");
+    expect(injectedHtml).not.toContain("<b>message</b>");
+    expect(injectedHtml).toContain("&lt;img src=x onerror=alert(&quot;name&quot;)&gt;");
+    expect(injectedHtml).toContain("&lt;script&gt;alert(&#39;email&#39;)&lt;/script&gt;@example.com");
+    expect(injectedHtml).toContain("&lt;b&gt;message&lt;/b&gt; &amp; &lt;i&gt;more&lt;/i&gt;");
+  });
+});

--- a/backend/emails/renderContactNotification.test.ts
+++ b/backend/emails/renderContactNotification.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { renderContactNotification } from "./renderContactNotification.ts";
+import type { ContactNotificationData } from "./renderContactNotification.ts";
 
-const sampleData = {
+const sampleData: ContactNotificationData = {
   name: "Jan Kowalski",
   email: "jan@example.com",
   message: "Czy ramka 30×40 jest dostępna w orzechu?\nPozdrawiam",

--- a/backend/emails/renderReturnRequest.test.ts
+++ b/backend/emails/renderReturnRequest.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderReturnRequest } from "./renderReturnRequest.ts";
+
+const sampleData = {
+  orderNumber: "42",
+  name: "Anna Nowak",
+  email: "anna@example.com",
+  reason: "Ramka nie pasuje do wnętrza.\nProszę o zwrot.",
+  bankAccount: "61 1090 1014 0000 0712 1981 2874",
+};
+
+describe("renderReturnRequest", () => {
+  const { subject, html, text } = renderReturnRequest(sampleData);
+
+  it("returns the { subject, html, text } shape", () => {
+    expect(typeof subject).toBe("string");
+    expect(typeof html).toBe("string");
+    expect(typeof text).toBe("string");
+  });
+
+  it("pins the subject", () => {
+    expect(subject).toBe("Zwrot towaru — zamówienie #42");
+  });
+
+  it.each(["html", "text"] as const)("includes the form data in %s", (channel) => {
+    const output = channel === "html" ? html : text;
+    expect(output).toContain("#42");
+    expect(output).toContain("Anna Nowak");
+    expect(output).toContain("anna@example.com");
+    expect(output).toContain("61 1090 1014 0000 0712 1981 2874");
+    expect(output).toContain("Ramka nie pasuje do wnętrza.");
+  });
+
+  it("preserves reason line breaks in html", () => {
+    expect(html).toContain("wnętrza.<br>Proszę o zwrot.");
+  });
+
+  it("escapes an HTML-injection attempt in every user-controlled field", () => {
+    const { html: injectedHtml } = renderReturnRequest({
+      orderNumber: '<img src=x onerror=alert("order")>',
+      name: "<script>alert('name')</script>",
+      email: "<b>email</b>@example.com",
+      reason: "<i>reason</i> & more",
+      bankAccount: "<u>account</u>",
+    });
+    expect(injectedHtml).not.toContain("<img");
+    expect(injectedHtml).not.toContain("<script");
+    expect(injectedHtml).not.toContain("<b>email</b>");
+    expect(injectedHtml).not.toContain("<i>reason</i>");
+    expect(injectedHtml).not.toContain("<u>account</u>");
+    expect(injectedHtml).toContain("&lt;img src=x onerror=alert(&quot;order&quot;)&gt;");
+    expect(injectedHtml).toContain("&lt;script&gt;alert(&#39;name&#39;)&lt;/script&gt;");
+    expect(injectedHtml).toContain("&lt;b&gt;email&lt;/b&gt;@example.com");
+    expect(injectedHtml).toContain("&lt;i&gt;reason&lt;/i&gt; &amp; more");
+    expect(injectedHtml).toContain("&lt;u&gt;account&lt;/u&gt;");
+  });
+});

--- a/backend/emails/renderReturnRequest.test.ts
+++ b/backend/emails/renderReturnRequest.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { renderReturnRequest } from "./renderReturnRequest.ts";
+import type { ReturnRequestData } from "./renderReturnRequest.ts";
 
-const sampleData = {
+const sampleData: ReturnRequestData = {
   orderNumber: "42",
   name: "Anna Nowak",
   email: "anna@example.com",


### PR DESCRIPTION
## Summary
- Render tests for contact, return-request, and complaint-request email templates
- Subjects pinned, HTML-injection asserted inert per user field, shape asserted

## Test plan
- [x] cd backend && npm test — 95/95
- [x] npm run typecheck — clean

Closes #131