### PR TITLE
refactor: pure bannerPresentation core for the revenue banner

### DIFF
--- a/src/pages/admin/RevenueBanner.tsx
+++ b/src/pages/admin/RevenueBanner.tsx
@@ -1,30 +1,20 @@
 import { formatPln, type QuarterRevenue } from "@sznyt/shared";
 import Skeleton from "../../components/Skeleton";
 import { useResource } from "../../hooks/useResource";
+import { bannerPresentation, type BannerTone } from "./bannerPresentation";
 
-const THRESHOLD_STYLES: Record<
-  QuarterRevenue["threshold"],
-  { container: string; bar: string; message: string | null }
-> = {
+const TONE_STYLES: Record<BannerTone, { container: string; bar: string }> = {
   safe: {
     container: "border-green-600 bg-green-50 text-green-900",
     bar: "bg-green-600",
-    message: null,
   },
-  warn70: {
+  warn: {
     container: "border-amber-500 bg-amber-50 text-amber-900",
     bar: "bg-amber-500",
-    message: "Ponad 70% limitu — czas zaplanować rejestrację działalności.",
   },
-  warn90: {
+  danger: {
     container: "border-red-600 bg-red-50 text-red-900",
     bar: "bg-red-600",
-    message: "Ponad 90% limitu — rozpocznij rejestrację działalności.",
-  },
-  over: {
-    container: "border-red-600 bg-red-50 text-red-900",
-    bar: "bg-red-600",
-    message: "Limit przekroczony — obowiązek rejestracji działalności w ciągu 7 dni!",
   },
 };
 
@@ -49,8 +39,8 @@ function RevenueBanner() {
     );
   }
 
-  const styles = THRESHOLD_STYLES[data.threshold];
-  const percent = (data.totalPln / data.capPln) * 100;
+  const { tone, message, percent } = bannerPresentation(data);
+  const styles = TONE_STYLES[tone];
 
   return (
     <div className={`w-full border-l-4 border p-4 font-dm-sans ${styles.container}`}>
@@ -65,12 +55,9 @@ function RevenueBanner() {
         </p>
       </div>
       <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-white/60">
-        <div
-          className={`h-full rounded-full ${styles.bar}`}
-          style={{ width: `${Math.min(percent, 100)}%` }}
-        />
+        <div className={`h-full rounded-full ${styles.bar}`} style={{ width: `${percent}%` }} />
       </div>
-      {styles.message && <p className="mt-2 text-sm font-medium">{styles.message}</p>}
+      {message && <p className="mt-2 text-sm font-medium">{message}</p>}
     </div>
   );
 }

--- a/src/pages/admin/bannerPresentation.test.ts
+++ b/src/pages/admin/bannerPresentation.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { bannerPresentation } from "./bannerPresentation";
-import type { QuarterRevenue } from "@sznyt/shared";
+import type { QuarterRevenue, QuarterRevenueThreshold } from "@sznyt/shared";
 
 const CAP_PLN = 10813.5;
 
-function quarterRevenue(
-  totalPln: number,
-  threshold: QuarterRevenue["threshold"],
-): QuarterRevenue {
+function quarterRevenue(totalPln: number, threshold: QuarterRevenueThreshold): QuarterRevenue {
   return { quarter: 3, year: 2026, totalPln, capPln: CAP_PLN, threshold };
 }
 
@@ -26,10 +23,12 @@ describe("bannerPresentation", () => {
     );
   });
 
-  it("warn90: danger tone, start-registration copy", () => {
+  it("warn90: danger tone, start-registration copy, exactly 90 at the boundary", () => {
+    // 9732.15 = 10813.50 * 0.9 to the grosz
     const result = bannerPresentation(quarterRevenue(9732.15, "warn90"));
     expect(result.tone).toBe("danger");
     expect(result.message).toBe("Ponad 90% limitu — rozpocznij rejestrację działalności.");
+    expect(result.percent).toBe(90);
   });
 
   it("over: danger tone, statutory 7-day registration-obligation copy", () => {

--- a/src/pages/admin/bannerPresentation.test.ts
+++ b/src/pages/admin/bannerPresentation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { bannerPresentation } from "./bannerPresentation";
+import type { QuarterRevenue } from "@sznyt/shared";
+
+const CAP_PLN = 10813.5;
+
+function quarterRevenue(
+  totalPln: number,
+  threshold: QuarterRevenue["threshold"],
+): QuarterRevenue {
+  return { quarter: 3, year: 2026, totalPln, capPln: CAP_PLN, threshold };
+}
+
+describe("bannerPresentation", () => {
+  it("safe: green tone, no message", () => {
+    const result = bannerPresentation(quarterRevenue(238.99, "safe"));
+    expect(result.tone).toBe("safe");
+    expect(result.message).toBeNull();
+  });
+
+  it("warn70: warn tone, plan-registration copy", () => {
+    const result = bannerPresentation(quarterRevenue(7569.45, "warn70"));
+    expect(result.tone).toBe("warn");
+    expect(result.message).toBe(
+      "Ponad 70% limitu — czas zaplanować rejestrację działalności.",
+    );
+  });
+
+  it("warn90: danger tone, start-registration copy", () => {
+    const result = bannerPresentation(quarterRevenue(9732.15, "warn90"));
+    expect(result.tone).toBe("danger");
+    expect(result.message).toBe("Ponad 90% limitu — rozpocznij rejestrację działalności.");
+  });
+
+  it("over: danger tone, statutory 7-day registration-obligation copy", () => {
+    const result = bannerPresentation(quarterRevenue(10900, "over"));
+    expect(result.tone).toBe("danger");
+    expect(result.message).toBe(
+      "Limit przekroczony — obowiązek rejestracji działalności w ciągu 7 dni!",
+    );
+  });
+
+  it("computes percent of the cap", () => {
+    const result = bannerPresentation(quarterRevenue(238.99, "safe"));
+    expect(result.percent).toBeCloseTo(2.21, 2);
+  });
+
+  it("lands exactly on 70 at the warn70 boundary — no float drift", () => {
+    // 7569.45 = 10813.50 * 0.7 to the grosz
+    expect(bannerPresentation(quarterRevenue(7569.45, "warn70")).percent).toBe(70);
+  });
+
+  it("reaches exactly 100 at the cap", () => {
+    expect(bannerPresentation(quarterRevenue(CAP_PLN, "warn90")).percent).toBe(100);
+  });
+
+  it("clamps percent to 100 when revenue exceeds the cap", () => {
+    expect(bannerPresentation(quarterRevenue(12000, "over")).percent).toBe(100);
+  });
+});

--- a/src/pages/admin/bannerPresentation.ts
+++ b/src/pages/admin/bannerPresentation.ts
@@ -1,4 +1,4 @@
-import type { QuarterRevenue } from "@sznyt/shared";
+import type { QuarterRevenue, QuarterRevenueThreshold } from "@sznyt/shared";
 
 export type BannerTone = "safe" | "warn" | "danger";
 
@@ -8,14 +8,8 @@ export type BannerPresentation = {
   percent: number;
 };
 
-/**
- * Pure presentation core for the DN revenue-cap banner: maps the backend's
- * quarter summary to a tone, the Polish warning copy, and a clamped percent.
- * The component renders this result — no logic in JSX (same pattern as
- * ADR-0003's checkout assembly).
- */
 const THRESHOLD_PRESENTATION: Record<
-  QuarterRevenue["threshold"],
+  QuarterRevenueThreshold,
   { tone: BannerTone; message: string | null }
 > = {
   safe: { tone: "safe", message: null },
@@ -33,6 +27,12 @@ const THRESHOLD_PRESENTATION: Record<
   },
 };
 
+/**
+ * Pure presentation core for the DN revenue-cap banner: maps the backend's
+ * quarter summary to a tone, the Polish warning copy, and a clamped percent.
+ * The component renders this result — no logic in JSX (same pattern as
+ * ADR-0003's checkout assembly).
+ */
 export function bannerPresentation(quarterRevenue: QuarterRevenue): BannerPresentation {
   const { tone, message } = THRESHOLD_PRESENTATION[quarterRevenue.threshold];
   // integer grosze keep boundary percentages exact (mirrors computeQuarterRevenue)

--- a/src/pages/admin/bannerPresentation.ts
+++ b/src/pages/admin/bannerPresentation.ts
@@ -1,0 +1,43 @@
+import type { QuarterRevenue } from "@sznyt/shared";
+
+export type BannerTone = "safe" | "warn" | "danger";
+
+export type BannerPresentation = {
+  tone: BannerTone;
+  message: string | null;
+  percent: number;
+};
+
+/**
+ * Pure presentation core for the DN revenue-cap banner: maps the backend's
+ * quarter summary to a tone, the Polish warning copy, and a clamped percent.
+ * The component renders this result — no logic in JSX (same pattern as
+ * ADR-0003's checkout assembly).
+ */
+const THRESHOLD_PRESENTATION: Record<
+  QuarterRevenue["threshold"],
+  { tone: BannerTone; message: string | null }
+> = {
+  safe: { tone: "safe", message: null },
+  warn70: {
+    tone: "warn",
+    message: "Ponad 70% limitu — czas zaplanować rejestrację działalności.",
+  },
+  warn90: {
+    tone: "danger",
+    message: "Ponad 90% limitu — rozpocznij rejestrację działalności.",
+  },
+  over: {
+    tone: "danger",
+    message: "Limit przekroczony — obowiązek rejestracji działalności w ciągu 7 dni!",
+  },
+};
+
+export function bannerPresentation(quarterRevenue: QuarterRevenue): BannerPresentation {
+  const { tone, message } = THRESHOLD_PRESENTATION[quarterRevenue.threshold];
+  // integer grosze keep boundary percentages exact (mirrors computeQuarterRevenue)
+  const totalGr = Math.round(quarterRevenue.totalPln * 100);
+  const capGr = Math.round(quarterRevenue.capPln * 100);
+  const percent = Math.min((totalGr * 100) / capGr, 100);
+  return { tone, message, percent };
+}


### PR DESCRIPTION
## Summary
- Extracts the revenue banner's presentation logic into a pure `bannerPresentation(quarterRevenue)` → `{ tone, message, percent }` (same pure-core-plus-thin-view move as ADR-0003)
- Threshold → tone/message table, all Polish copy (incl. the statutory 7-day registration-obligation warning), and grosze-exact percent math with its clamp now pinned by 8 vitest cases
- `RevenueBanner.tsx` becomes thin JSX; only tone → Tailwind classes stays in the view
- Note: per spec, percent is clamped inside the core, so an over-cap quarter now displays 100.0% (the red over-cap message still fires)

## Test plan
- [x] `npm test` — 219 passed (30 files), incl. new `src/pages/admin/bannerPresentation.test.ts`
- [x] `npm run typecheck` and `npm run lint` clean

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)