### PR TITLE
refactor: concentrate public-form routes into one declaration

### DIFF
--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -1,17 +1,41 @@
 import express from "express";
 import { rateLimit } from "express-rate-limit";
 import {
+  CONTACT_FORM_FIELDS,
+  RETURN_FORM_FIELDS,
+  COMPLAINT_FORM_FIELDS,
+} from "@sznyt/shared";
+import {
   renderContactNotification,
   renderReturnRequest,
   renderComplaintRequest,
 } from "../emails/index.ts";
 
 /**
+ * How a form responds when the notification email fails to send (issue #133).
+ * The difference is intentional and load-bearing — do not unify:
+ *
+ * - "email-is-best-effort": the submission already succeeded (contact stores
+ *   the message in the DB first), so a send failure is logged and the response
+ *   still succeeds. Everything outside the send — the DB write included —
+ *   propagates to the shared serverError middleware (issue #115).
+ * - "fallback-address-500": nothing was persisted, so a send failure loses the
+ *   request — answer 500 with a body carrying the fallback contact address.
+ */
+const CATCH_POLICIES = ["email-is-best-effort", "fallback-address-500"];
+
+const FALLBACK_ADDRESS_ERROR =
+  "Błąd serwera. Spróbuj ponownie lub napisz bezpośrednio na kontakt@sznytdesign.pl.";
+
+/**
  * Public form routes (issue #108): contact, return (zwrot), and complaint
- * (reklamacja). All three share one rate-limit bucket — a burst on any form
- * counts against the same per-IP limit. Contact failures propagate to the
- * shared serverError middleware (issue #115); zwrot/reklamacja keep local
- * catches because their 500 body carries a fallback contact address.
+ * (reklamacja). Each form is a declaration of { fields, render, catchPolicy }
+ * over one shared skeleton (issue #133): honeypot check → required-fields
+ * guard → optional persist → render → send. Required-field lists come from
+ * @sznyt/shared so the frontend submit bodies are typed from the same source.
+ *
+ * All three share one rate-limit bucket — a burst on any form counts against
+ * the same per-IP limit.
  *
  * @param {object} deps
  * @param {object} deps.prisma
@@ -31,66 +55,63 @@ export function createFormsRouter({ prisma, mailer }) {
     message: { error: "Zbyt wiele prób. Spróbuj ponownie za chwilę." },
   });
 
-  // submit contact form
-  router.post("/contact", formLimiter, async function submitContact(req, res) {
-    const { name, email, message, _hp } = req.body;
-    if (_hp) return res.json({ ok: true });
-    if (!name || !email || !message) {
-      return res.status(400).json({ error: "Wszystkie pola są wymagane." });
+  /**
+   * @param {string} path
+   * @param {object} form
+   * @param {readonly string[]} form.fields required fields; missing any → 400
+   * @param {(data: object) => object} form.render email renderer for the picked fields
+   * @param {"email-is-best-effort" | "fallback-address-500"} form.catchPolicy
+   * @param {(data: object) => Promise<object>} [form.persist] runs before the
+   *   send, outside its catch; its return value becomes the response body
+   */
+  function defineFormRoute(path, { fields, render, catchPolicy, persist }) {
+    if (!CATCH_POLICIES.includes(catchPolicy)) {
+      throw new Error(`Unknown catchPolicy for ${path}: ${catchPolicy}`);
     }
-    const contactMessage = await prisma.contactMessage.create({
-      data: { name, email, message },
+
+    router.post(path, formLimiter, async function submitForm(req, res) {
+      if (req.body._hp) return res.json({ ok: true });
+      if (fields.some((field) => !req.body[field])) {
+        return res.status(400).json({ error: "Wszystkie pola są wymagane." });
+      }
+      const data = Object.fromEntries(fields.map((field) => [field, req.body[field]]));
+
+      const record = persist ? await persist(data) : null;
+      try {
+        await mailer.send({
+          to: process.env.CONTACT_RECIPIENT,
+          replyTo: data.email,
+          ...render(data),
+        });
+      } catch (err) {
+        console.error(`Błąd wysyłania emaila (${path}):`, err.message);
+        if (catchPolicy === "fallback-address-500") {
+          return res.status(500).json({ error: FALLBACK_ADDRESS_ERROR });
+        }
+      }
+      res.json(record ?? { ok: true });
     });
-    try {
-      await mailer.send({
-        to: process.env.CONTACT_RECIPIENT,
-        replyTo: email,
-        ...renderContactNotification({ name, email, message }),
-      });
-    } catch (emailErr) {
-      console.error("Błąd wysyłania emaila:", emailErr.message);
-    }
-    res.json(contactMessage);
+  }
+
+  defineFormRoute("/contact", {
+    fields: CONTACT_FORM_FIELDS,
+    render: renderContactNotification,
+    catchPolicy: "email-is-best-effort",
+    persist: function storeContactMessage(data) {
+      return prisma.contactMessage.create({ data });
+    },
   });
 
-  // submit return form
-  router.post("/zwrot", formLimiter, async function submitReturn(req, res) {
-    const { orderNumber, name, email, reason, bankAccount, _hp } = req.body;
-    if (_hp) return res.json({ ok: true });
-    if (!orderNumber || !name || !email || !reason || !bankAccount) {
-      return res.status(400).json({ error: "Wszystkie pola są wymagane." });
-    }
-    try {
-      await mailer.send({
-        to: process.env.CONTACT_RECIPIENT,
-        replyTo: email,
-        ...renderReturnRequest({ orderNumber, name, email, reason, bankAccount }),
-      });
-      res.json({ ok: true });
-    } catch (err) {
-      console.error("Błąd wysyłania zwrotu:", err.message);
-      res.status(500).json({ error: "Błąd serwera. Spróbuj ponownie lub napisz bezpośrednio na kontakt@sznytdesign.pl." });
-    }
+  defineFormRoute("/zwrot", {
+    fields: RETURN_FORM_FIELDS,
+    render: renderReturnRequest,
+    catchPolicy: "fallback-address-500",
   });
 
-  // submit complaint form
-  router.post("/reklamacja", formLimiter, async function submitComplaint(req, res) {
-    const { orderNumber, name, email, description, _hp } = req.body;
-    if (_hp) return res.json({ ok: true });
-    if (!orderNumber || !name || !email || !description) {
-      return res.status(400).json({ error: "Wszystkie pola są wymagane." });
-    }
-    try {
-      await mailer.send({
-        to: process.env.CONTACT_RECIPIENT,
-        replyTo: email,
-        ...renderComplaintRequest({ orderNumber, name, email, description }),
-      });
-      res.json({ ok: true });
-    } catch (err) {
-      console.error("Błąd wysyłania reklamacji:", err.message);
-      res.status(500).json({ error: "Błąd serwera. Spróbuj ponownie lub napisz bezpośrednio na kontakt@sznytdesign.pl." });
-    }
+  defineFormRoute("/reklamacja", {
+    fields: COMPLAINT_FORM_FIELDS,
+    render: renderComplaintRequest,
+    catchPolicy: "fallback-address-500",
   });
 
   return router;

--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -58,7 +58,8 @@ export function createFormsRouter({ prisma, mailer }) {
   /**
    * @param {string} path
    * @param {object} form
-   * @param {readonly string[]} form.fields required fields; missing any → 400
+   * @param {readonly string[]} form.fields required fields; missing any → 400.
+   *   Must include "email" — the skeleton sets it as the notification's replyTo
    * @param {(data: object) => object} form.render email renderer for the picked fields
    * @param {"email-is-best-effort" | "fallback-address-500"} form.catchPolicy
    * @param {(data: object) => Promise<object>} [form.persist] runs before the

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,4 +22,14 @@ export { ORDER_NOTE_MAX_LENGTH } from "./orderNote.ts";
 export { formatPln } from "./money.ts";
 export { ADMIN_ROLE, isAdminRole } from "./roles.ts";
 export { REVENUE_THRESHOLDS } from "./revenue.ts";
+export {
+  CONTACT_FORM_FIELDS,
+  RETURN_FORM_FIELDS,
+  COMPLAINT_FORM_FIELDS,
+} from "./publicForms.ts";
+export type {
+  ContactFormBody,
+  ReturnFormBody,
+  ComplaintFormBody,
+} from "./publicForms.ts";
 export type { QuarterRevenue, QuarterRevenueThreshold } from "./revenue.ts";

--- a/packages/shared/src/publicForms.ts
+++ b/packages/shared/src/publicForms.ts
@@ -1,0 +1,26 @@
+/**
+ * Required-field contracts for the public forms (contact, return, complaint).
+ * Single-sourced here so the backend guard and the frontend submit body cannot
+ * drift (issue #133): the backend rejects a submission missing any listed
+ * field with a 400; the frontend types its request body from the same list.
+ */
+export const CONTACT_FORM_FIELDS = ["name", "email", "message"] as const;
+
+export const RETURN_FORM_FIELDS = [
+  "orderNumber",
+  "name",
+  "email",
+  "reason",
+  "bankAccount",
+] as const;
+
+export const COMPLAINT_FORM_FIELDS = [
+  "orderNumber",
+  "name",
+  "email",
+  "description",
+] as const;
+
+export type ContactFormBody = Record<(typeof CONTACT_FORM_FIELDS)[number], string>;
+export type ReturnFormBody = Record<(typeof RETURN_FORM_FIELDS)[number], string>;
+export type ComplaintFormBody = Record<(typeof COMPLAINT_FORM_FIELDS)[number], string>;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import type { ContactFormBody } from "@sznyt/shared";
 import Seo from "../components/Seo";
 import { usePublicForm } from "../hooks/usePublicForm";
 
@@ -14,8 +15,11 @@ function Contact() {
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
+    // Typing the body from the shared contract keeps this form in lockstep
+    // with the backend's required-fields guard (issue #133).
+    const body: ContactFormBody = { name, email, message };
     await submit(
-      { name, email, message },
+      body,
       {
         onSuccess: () => {
           setName("");

--- a/src/pages/Zwroty.tsx
+++ b/src/pages/Zwroty.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import type { ComplaintFormBody, ReturnFormBody } from "@sznyt/shared";
 import Seo from "../components/Seo";
 import { usePublicForm } from "../hooks/usePublicForm";
 
@@ -19,7 +20,10 @@ function ZwrotForm() {
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    await submit({ orderNumber, name, email, reason, bankAccount });
+    // Typed from the shared contract so the form can't drift from the
+    // backend's required-fields guard (issue #133).
+    const body: ReturnFormBody = { orderNumber, name, email, reason, bankAccount };
+    await submit(body);
   }
 
   if (success)
@@ -88,7 +92,8 @@ function ReklamacjaForm() {
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    await submit({ orderNumber, name, email, description });
+    const body: ComplaintFormBody = { orderNumber, name, email, description };
+    await submit(body);
   }
 
   if (success)


### PR DESCRIPTION
## Summary
- The three near-duplicate public-form route closures (contact, zwrot, reklamacja) become declarations of `{ fields, render, catchPolicy }` over one `defineFormRoute` skeleton: honeypot → required-fields guard → optional persist → render → send.
- The load-bearing per-form catch policy survives as an explicit parameter: `"email-is-best-effort"` (contact — message already stored, DB errors still propagate to the shared error handler) vs `"fallback-address-500"` (zwrot/reklamacja). The escape hatch was not needed.
- Required-field lists are single-sourced in `@sznyt/shared` (`publicForms.ts`); the frontend types its submit bodies from them, so form and backend guard can't drift (compile error instead).

## Behaviour
No observable HTTP behaviour change: same honeypot response, 400 guard, response bodies, status codes, and error propagation. Only send-failure log messages unified to include the route path. Verified line-by-line against the old routes in review.

## Test plan
- [x] Existing DB-backed form route tests stay the seam and are untouched — 8/8 pass
- [x] Full suites green: 219 frontend/shared, 95 backend unit, 59 backend DB
- [x] Typecheck (frontend + backend) and lint clean
- [x] Two-axis review (standards + spec) run; one finding fixed (email-field contract documented on the skeleton)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)