### PR TITLE
docs: Clerk session-token step and production migration runbook

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,7 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **Provider:** Clerk.
 - **Admin role:** `publicMetadata.role === "admin"` on the Clerk user. Read in backend via `@clerk/express` session claims; in frontend via a `useIsAdmin()` hook wrapping `useUser()`. Both surfaces share one source of truth.
 - **Two admins:** Adrian + wife. Each has own Clerk account with the admin role.
+- **Per-instance Clerk config:** the backend's half of that source of truth arrives through the JWT, so every Clerk instance (local dev, demo, production) needs the session token customized with `{"metadata": "{{user.public_metadata}}"}`. Without it the frontend admits the user and every admin endpoint 403s. Users and metadata don't carry across instances either. Setup: `docs/DEPLOY-DEMO.md` § 2.
 
 ## External services
 
@@ -88,6 +89,7 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **Quarterly revenue cap is monitored, not enforced.** Admin sees a banner with running total + 70 % / 90 % / over thresholds. Crossing it is a manual action (begin registration), not an automatic block.
 - **Production launches only with real products.** The domain flip waits for frames, photos, and descriptions (issues labeled `waiting-for-products`). The interim public artifact is the recruiter demo, not the domain.
 - **`noindex` until real photos.** Site ships with `<meta name="robots" content="noindex">` at the layout level. Lifted only after **real** product photos land — AI-rendered placeholder imagery does not lift it.
+- **Deployed databases only ever see `prisma migrate deploy`.** Run by the host at build time, never by hand. `migrate dev` is local-only — it can reset the database — and `backend/seed.js` wipes the product table, so it never runs against a deployed environment. Procedure: `docs/runbooks/production-migrations.md`.
 - **Admin must work at 375 px.** Wife uses phone as primary admin device.
 - **Returns and complaints are email-only.** No DB workflow. Forms post to `kontakt@sznytdesign.pl`.
 

--- a/docs/DEPLOY-DEMO.md
+++ b/docs/DEPLOY-DEMO.md
@@ -25,8 +25,27 @@ Stack: **Vercel** (frontend) + **Render** (backend) + **Neon** (Postgres) + **Cl
 4. From the dashboard sidebar → **API keys**:
    - Copy the **Publishable key** (`pk_test_...`) → for Vercel as `VITE_CLERK_PUBLISHABLE_KEY`
    - Copy the **Secret key** (`sk_test_...`) → for Render as `CLERK_SECRET_KEY`
+5. **Customize the session token** — required for the admin panel. Sidebar → **Sessions** → **Customize session token** → **Edit**, and set the claims to:
+
+   ```json
+   { "metadata": "{{user.public_metadata}}" }
+   ```
+
+   Save.
 
 > Free tier covers up to 10 000 MAUs. Won't be a problem for a demo.
+
+> **Step 5 is per Clerk instance and easy to forget.** The backend reads the admin role from the JWT (`sessionClaims.metadata.role`, `backend/middleware/adminAuth.js`) while the frontend reads it from the user profile (`user.publicMetadata.role`, `src/hooks/useIsAdmin.ts`). Skip the claim and the two disagree: `/admin` renders, then every admin API call 403s. Do this again on every new instance — including the future production one. The claim key must be exactly `metadata`, mapping the whole `public_metadata` object — not `{"role": "{{user.public_metadata.role}}"}`.
+
+### Granting yourself admin (optional)
+
+The demo intentionally ships with **no admin user** — a recruiter who signs up sees the shop, not the back office. To use the back office yourself:
+
+1. Sign up on the deployed site (this Clerk instance has its own user pool — your local user does not carry over).
+2. Clerk dashboard → **Users** → your user → **Public metadata** → set `{ "role": "admin" }`. The value is case-sensitive: `isAdminRole` accepts `"admin"` only, not `"Admin"`.
+3. **Sign out and back in.** Already-issued tokens keep the old claims until they refresh; reloading alone will not fix a 403.
+
+`publicMetadata` ships to the browser on every session — a role label is fine there, secrets never are. The frontend `AdminGuard` only redirects; the backend `requireAdmin` 403 is the actual security boundary.
 
 ---
 
@@ -158,7 +177,8 @@ Open the Vercel URL and confirm:
 - [ ] In Neon SQL Editor: `SELECT id, status, total FROM "Order" ORDER BY id DESC LIMIT 1;` → status `paid`, and `SELECT name, stock FROM "Product";` → stock decremented by the purchased quantity
 - [ ] In Stripe dashboard → Webhooks → the endpoint, **Resend** the `checkout.session.completed` event → returns 200 and no duplicate order appears (idempotency)
 - [ ] `/kontakt` submits without error (backend logs `[demo] sendEmail skipped`)
-- [ ] `/admin` is gated by Clerk — sign up with email, you'll land on `/admin` with no admin permissions (intentional — admin role isn't granted)
+- [ ] `/admin` is gated — sign up with email, then open `/admin`: you're redirected to `/` because no admin role is granted (intentional)
+- [ ] If you granted yourself admin (step 2): `/admin` lists products **and** `/admin/zamowienia` loads without an error banner. Both failing while the products table renders means the session-token claim is missing — see Troubleshooting
 
 ---
 
@@ -194,6 +214,8 @@ Then on GitHub:
 | Payment succeeds but no order in DB | Webhook signature mismatch or wrong endpoint URL | Check Render logs for `Webhook error`; re-copy `whsec_...` from the exact endpoint, confirm the URL ends with `/webhook` |
 | Stripe checkout page shows no product image | `FRONTEND_URL` wrong or image path 404s | Open `<FRONTEND_URL>/images/szachownica-studio.webp` in a browser — must resolve publicly |
 | First request after some idle time hangs | Render free-tier cold start | Wait ~30 s; the service is waking. No fix on free tier |
+| `/admin` renders but "Nie udało się załadować zamówień/przychodu" (products table is fine) | Session token has no `metadata` claim — backend 403s `/orders` and `/revenue` | Do step 2.5, then sign out and back in. Confirm in DevTools → Network: `403` (not 401) on `orders` is this exact cause |
+| Redirected off `/admin` to the home page | `publicMetadata.role` not `"admin"` on this instance's user | Clerk → Users → Public metadata → `{ "role": "admin" }`, sign out/in |
 | Site appears in Google search | `noindex` meta missing | Check `index.html` — should have `<meta name="robots" content="noindex, nofollow" />` |
 
 ---

--- a/docs/runbooks/production-migrations.md
+++ b/docs/runbooks/production-migrations.md
@@ -1,0 +1,91 @@
+# Runbook: Database migrations in production
+
+Who this is for: **the developer** (Adrian / Claude Code).
+When to use it: any time a change touches `backend/prisma/schema.prisma` and will reach a deployed environment.
+
+The short version: **you never run a migration against production by hand.** The host runs it for you at build time. Your job is to make sure the migration that gets deployed is one you already proved safe locally.
+
+Hosting note: the demo backend runs on Render (`render.yaml`); real production moves to Railway at launch. Both run the same `npm run build`, so everything below applies unchanged — substitute your host's name for "Render".
+
+---
+
+## The one rule
+
+| Environment | Command | Who runs it |
+|---|---|---|
+| Local dev | `npx prisma migrate dev` | You |
+| Any deployed env | `npx prisma migrate deploy` | the host, via `npm run build` |
+
+`migrate dev` is a **development-only** command. It compares the schema to the database and, when it can't reconcile them, **offers to reset the database — dropping every table**. Against production that is unrecoverable data loss: real orders, real customers, real money already taken.
+
+`migrate deploy` applies pending migration files and nothing else. It never resets, never prompts, never generates a new migration. It's already wired into `backend/package.json` (`"build": "prisma generate && prisma migrate deploy"`), which `render.yaml` runs as the build command.
+
+**So: never run `migrate dev` with `DATABASE_URL` pointing at a deployed database.** The realistic way this goes wrong is not a typo in the command — it's a `.env` still holding a Neon connection string from a debugging session. Check `DATABASE_URL` before you run anything.
+
+---
+
+## Normal flow: shipping a schema change
+
+1. **Locally**, edit `backend/prisma/schema.prisma`, then from `backend/`:
+   ```bash
+   npx prisma migrate dev --name descriptive_name
+   npx prisma generate
+   ```
+   This writes a new folder under `backend/prisma/migrations/`.
+2. **Commit the migration folder.** It is the deployable artifact — a schema change without its migration file deploys as a broken app (the client expects columns the database doesn't have).
+3. **Review the generated SQL** before pushing. Open the new `migration.sql` and read it. See the destructive-change checklist below.
+4. Push / merge to `main`. Render redeploys, `npm run build` runs `migrate deploy`, the migration applies.
+5. **Verify** in Neon's SQL Editor that the table looks right, and that the site still loads.
+
+There is no manual step against the production database in this flow. If you find yourself opening a SQL console to make a schema change, stop — that drift will break the next `migrate deploy`.
+
+## Before you commit: destructive-change checklist
+
+Read the generated `migration.sql` and look for:
+
+- `DROP TABLE` / `DROP COLUMN` — the data in it is gone permanently. Is it referenced anywhere in `backend/` or `src/`?
+- `ALTER COLUMN ... SET NOT NULL` on an existing table — fails outright if any existing row has a NULL there. Add the column nullable, backfill, then tighten in a second migration.
+- Adding a required column without a default — same failure.
+- Renames — Prisma usually emits drop + create, which **loses the data**. If you want a true rename, hand-edit the SQL to `ALTER TABLE ... RENAME COLUMN`.
+- Anything touching `Order` or `OrderItem` — these hold financial records for orders customers already paid for. Treat as append-only: add columns, don't reshape.
+
+A failed migration on Render fails the **build**, so the old version keeps serving — that's the good outcome. A migration that *succeeds* but drops data is the bad one, and only the review above catches it.
+
+## Never seed production
+
+`backend/seed.js` starts with `prisma.product.deleteMany()` — it wipes the product table by design, because its job is to reset local dev to a known state.
+
+Against production that deletes the live catalogue, and depending on FK constraints either fails halfway or takes order history with it. **`npm run seed` has no legitimate production use.** Products in production are created through the admin panel (`/admin/produkty/nowy`).
+
+The demo environment is the one exception, and only because it holds nothing real — its one-off seeding is done through Neon's SQL Editor (`docs/DEPLOY-DEMO.md`), not this script.
+
+## Backups
+
+Both Neon and Railway offer point-in-time restore, with the retention window depending on the plan — **check the actual window on your plan before you rely on it**, don't assume. PITR covers "the migration was wrong, rewind an hour". It does **not** cover noticing the mistake three weeks later.
+
+So before any migration that drops or reshapes a column holding order data, take an explicit snapshot first — on Neon, dashboard → **Branches** → branch from the current state (cheap, copy-on-write); on Railway, a manual backup or `pg_dump`. That snapshot is the difference between a bad afternoon and a lost order history.
+
+## If a migration fails on deploy
+
+1. The build fails and the previous deploy keeps serving. Nothing is down. Don't rush.
+2. Read the build log — Prisma names the failing migration and the SQL error.
+3. Prisma marks the migration as failed in the `_prisma_migrations` table; **later deploys will keep failing** until it's resolved, even after you fix the code.
+4. Fix forward: correct the migration locally, verify against a local database, commit, redeploy. Avoid editing an already-applied migration file — write a new one.
+5. If the migration partially applied and left the schema inconsistent, restoring the Neon branch you took beforehand is the fastest way out.
+
+## Going live: environment separation
+
+Production is a *deployment target*, not a git branch — same `main`, different env vars (see the discussion in `CONTEXT.md`). What must differ from the demo:
+
+- `DATABASE_URL` — its own Neon project. Never point two environments at one database.
+- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` — live mode, with a webhook endpoint registered against the production URL.
+- Clerk — production instance, which needs its own session-token customization and its own admin user (`docs/DEPLOY-DEMO.md` § 2).
+- `SMTP_*` — set, so order emails actually send (unset means skipped-and-logged).
+
+## Related
+
+- Schema: `backend/prisma/schema.prisma`; migrations: `backend/prisma/migrations/`
+- Build wiring: `backend/package.json` (`build` script), `render.yaml`
+- Local migration helper: the `prisma-migrate` skill (shows the diff and confirms the name before running)
+- Demo deploy: `docs/DEPLOY-DEMO.md`
+- Refunds and order-data handling: `docs/runbooks/refunds.md`


### PR DESCRIPTION
## Summary

Two documentation gaps found while getting the admin panel working on the demo deployment.

**Clerk session token (`docs/DEPLOY-DEMO.md`, `CONTEXT.md`)** — the admin role is read from `user.publicMetadata.role` on the frontend but from `sessionClaims.metadata.role` on the backend. A Clerk instance without the session-token customization therefore admits the user to `/admin` and 403s every admin API call. That step was only recorded in an archived design doc, so deploying the demo walked straight into it. Adds it as step 2.5 of the deploy guide, a "granting yourself admin" subsection, two troubleshooting rows, and an invariant in `CONTEXT.md`.

Also fixes a smoke-test line that claimed a non-admin signup "lands on `/admin` with no admin permissions" — `AdminGuard` redirects them to `/`.

**`docs/runbooks/production-migrations.md`** (new) — written while nothing is at stake, before real orders exist. Covers `migrate dev` vs `migrate deploy` and why the former can drop a database, the destructive-SQL review checklist, why `seed.js` (which opens with `product.deleteMany()`) never runs against a deployed environment, backups, and failed-migration recovery.

## Test plan

- [x] Root cause verified live: `GET /orders` returned 403 (not 401) on the demo deployment; adding the `metadata` claim and re-signing-in fixed it
- [ ] Docs only — no code paths touched, nothing to run

## Related

Refs #59 (production Clerk session token + admin roles) — not closed by this PR; that issue is the actual production config action, and this only documents the procedure it will follow. Refs #29.