### PR TITLE
fix: separate product cards on the shop grid

### DIFF
--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -8,8 +8,15 @@ import { useResource } from "../hooks/useResource";
 function ProductCard({ product }: { product: Product }) {
   const [hovered, setHovered] = useState(false);
 
+  // Hairline separator, mobile only: the single column has no gutter to group by,
+  // so pad below the caption and rule the card's bottom edge — the line lands
+  // centred in the row gap. The last card is left open so it doesn't double up
+  // with the border-t on the materials strip below.
   return (
-    <Link to={`/sklep/${product.id}`}>
+    <Link
+      to={`/sklep/${product.id}`}
+      className="block border-b border-borders pb-16 last:border-b-0 last:pb-0 md:border-b-0 md:pb-0"
+    >
       <div
         className="overflow-hidden"
         onMouseEnter={() => setHovered(true)}
@@ -25,7 +32,7 @@ function ProductCard({ product }: { product: Product }) {
             style={{ backgroundImage: `url(${product.lifestyleImageUrl})` }}
           />
         </div>
-        <div className="pt-4 pb-6">
+        <div className="pt-4">
           <h2 className="font-cormorant text-2xl text-near-black font-light mb-1">
             {product.name}
           </h2>
@@ -88,8 +95,10 @@ function Shop() {
 
       {/* Product grid */}
       <section className="bg-warm-white px-6 py-8 md:py-16">
-        {/* max-w-4xl (not 6xl): keeps a 4:5 card + title inside one laptop viewport */}
-        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-10">
+        {/* max-w-4xl (not 6xl): keeps a 4:5 card + title inside one laptop viewport.
+            Row gap is much larger than the card's internal pt-4 so each image reads as
+            grouped with its own caption, not with the card below it. */}
+        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-y-16 md:gap-y-20 md:gap-x-10">
           {error ? (
             <p className="font-dm-sans text-sm text-red-600 col-span-2">{error}</p>
           ) : (


### PR DESCRIPTION
## Summary

On mobile the `/sklep` grid collapsed to one column where the row gap (56px) was only ~3.5x the card's internal image-to-caption gap (16px). Too weak a ratio to group a caption with its own image, so the column read as a continuous ribbon of image/text/image/text with no signal of where one product ended.

- Split the grid gap into axes (`gap-y-16 md:gap-y-20 md:gap-x-10`) so row separation is independent of the column gutter — gutters stay at 40px, rows get 64/80px.
- Dropped the caption's trailing `pb-6` so the text hugs its own image (16px inside vs 64px between = 4:1).
- Added a hairline separator on mobile only, using the existing `borders` token already used by the philosophy and materials strips.

The hairline is padded onto the card's **bottom** edge rather than the next card's top (i.e. not `divide-y`), so it lands centred in the row gap — 64px of air on each side — reading as a divider between two products rather than a lid on the one below. `last:border-b-0` keeps the final card open so it doesn't double up with the `border-t` on the materials strip.

## Verified in the browser

Measured on the running dev stack, not eyeballed:

| | mobile | desktop (1522x672) |
|---|---|---|
| caption bottom to line | 64.8px | n/a (no border) |
| line to next image | 64px | n/a |
| card border-bottom | 0.8px `rgb(229,226,221)` | `0px` |
| last card border | `0px` | `0px` |

Laptop viewport invariant still holds: card height 643px against a 674px viewport — 24px better than before, since removing `pb-6` shortened the card.

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npx eslint src/pages/Shop.tsx` clean
- [x] `npm run build` passes (chunk-size warning is pre-existing)
- [x] `/sklep` at 390px wide — hairline centred between cards, none after the last
- [x] `/sklep` at 1522x672 — no hairlines, 4:5 card + title inside one viewport