### PR TITLE
fix: refuse to boot when SMTP is configured without CONTACT_RECIPIENT

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,7 @@ All rendered by per-template render functions returning `{ subject, html, text }
 - **Production launches only with real products.** The domain flip waits for frames, photos, and descriptions (issues labeled `waiting-for-products`). The interim public artifact is the recruiter demo, not the domain.
 - **`noindex` until real photos.** Site ships with `<meta name="robots" content="noindex">` at the layout level. Lifted only after **real** product photos land — AI-rendered placeholder imagery does not lift it.
 - **Deployed databases only ever see `prisma migrate deploy`.** Run by the host at build time, never by hand. `migrate dev` is local-only — it can reset the database — and `backend/seed.js` wipes the product table, so it never runs against a deployed environment. Procedure: `docs/runbooks/production-migrations.md`.
+- **A half-configured service must not boot.** Env invariants live in `backend/config/bootEnv.ts` and are fatal: Stripe needs `STRIPE_WEBHOOK_SECRET` + `FRONTEND_URL`, and SMTP needs `CONTACT_RECIPIENT`. Each guards a state where the shop keeps answering 200 while payments or customer messages go nowhere. Absent services (no Stripe key, no SMTP host) are fine — that's demo mode.
 - **Admin must work at 375 px.** Wife uses phone as primary admin device.
 - **Returns and complaints are email-only.** No DB workflow. Forms post to `kontakt@sznytdesign.pl`.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,10 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret_here
 CLERK_PUBLISHABLE_KEY=pk_test_your_clerk_publishable_key_here
 CLERK_SECRET_KEY=sk_test_your_clerk_secret_key_here
 
+# Leave SMTP_* unset for demo mode (sends are skipped). If SMTP_HOST is set,
+# CONTACT_RECIPIENT is required — the backend refuses to boot without it,
+# because admin notifications would otherwise be rejected for having no
+# recipient while customers still see a success message.
 SMTP_HOST=mail.yourhost.com
 SMTP_PORT=587
 SMTP_USER=your@email.com

--- a/backend/config/boot.test.ts
+++ b/backend/config/boot.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration coverage for the boot guard (issue #143): the pure invariant
+ * table is unit-tested in bootEnv.test.ts, so what's left is the wiring —
+ * that a broken invariant actually kills the process and prints something the
+ * operator can act on, and that demo mode still comes up.
+ *
+ * The child inherits the developer's .env, so every variable this test cares
+ * about is passed explicitly. Empty string counts as unset for both dotenv
+ * (it won't overwrite a defined key) and the guard itself.
+ */
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const backendDir = fileURLToPath(new URL("..", import.meta.url));
+// Run tsx's CLI on this Node directly: going through `npx` needs a shell, and
+// a shell on Windows swallows the kill signal, orphaning the server.
+const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+
+interface BootResult {
+  exitCode: number | null;
+  output: string;
+}
+
+/**
+ * Boots index.js, and resolves once it either exits or prints its ready
+ * banner — a booting server never exits on its own, so it's killed instead.
+ */
+function boot(env: Record<string, string>, readyMarker = "Backend on"): Promise<BootResult> {
+  return new Promise(function runBoot(resolve, reject) {
+    const child = spawn(process.execPath, [tsxCli, "index.js"], {
+      cwd: backendDir,
+      env: { ...process.env, ...env },
+    });
+
+    let output = "";
+    function collect(chunk: Buffer) {
+      output += chunk.toString();
+      // A server that came up never exits — take the banner as the result.
+      if (output.includes(readyMarker)) {
+        child.kill();
+        resolve({ exitCode: null, output });
+      }
+    }
+
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+    child.on("error", reject);
+    child.on("close", (exitCode) => resolve({ exitCode, output }));
+  });
+}
+
+// tsx cold-starts, so give each boot room on a slow machine.
+const BOOT_TIMEOUT_MS = 60_000;
+
+describe("backend boot", () => {
+  it(
+    "refuses to start when SMTP is configured without a recipient",
+    async () => {
+      const { exitCode, output } = await boot({
+        SMTP_HOST: "smtp.example.com",
+        CONTACT_RECIPIENT: "",
+        STRIPE_SECRET_KEY: "",
+        PORT: "0",
+      });
+
+      expect(exitCode).toBe(1);
+      expect(output).toContain("FATAL");
+      expect(output).toContain("CONTACT_RECIPIENT");
+      expect(output).not.toContain("Backend on");
+    },
+    BOOT_TIMEOUT_MS,
+  );
+
+  it(
+    "starts in demo mode with no SMTP host and no recipient",
+    async () => {
+      const { output } = await boot({
+        SMTP_HOST: "",
+        CONTACT_RECIPIENT: "",
+        STRIPE_SECRET_KEY: "",
+        PORT: "0",
+      });
+
+      expect(output).toContain("[DEMO MODE]");
+      expect(output).not.toContain("FATAL");
+    },
+    BOOT_TIMEOUT_MS,
+  );
+});

--- a/backend/config/bootEnv.test.ts
+++ b/backend/config/bootEnv.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { findBootEnvErrors } from "./bootEnv.ts";
+
+const stripeConfigured = {
+  STRIPE_SECRET_KEY: "sk_test_123",
+  STRIPE_WEBHOOK_SECRET: "whsec_123",
+  FRONTEND_URL: "http://localhost:5173",
+};
+
+const smtpConfigured = {
+  SMTP_HOST: "s123.cyber-folks.pl",
+  CONTACT_RECIPIENT: "kontakt@sznytdesign.pl",
+};
+
+describe("findBootEnvErrors", () => {
+  it("passes an empty environment — demo mode configures neither Stripe nor SMTP", () => {
+    expect(findBootEnvErrors({})).toEqual([]);
+  });
+
+  it("passes a fully configured production environment", () => {
+    expect(findBootEnvErrors({ ...stripeConfigured, ...smtpConfigured })).toEqual([]);
+  });
+
+  it("rejects Stripe without a webhook secret", () => {
+    const errors = findBootEnvErrors({
+      ...stripeConfigured,
+      STRIPE_WEBHOOK_SECRET: undefined,
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("STRIPE_WEBHOOK_SECRET");
+  });
+
+  it("rejects Stripe without a frontend URL", () => {
+    const errors = findBootEnvErrors({ ...stripeConfigured, FRONTEND_URL: undefined });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("FRONTEND_URL");
+  });
+
+  it("rejects SMTP without a notification recipient — contact and returns mail would be lost", () => {
+    const errors = findBootEnvErrors({ ...stripeConfigured, SMTP_HOST: "smtp.example.com" });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("CONTACT_RECIPIENT");
+    expect(errors[0]).toContain("SMTP_HOST");
+  });
+
+  it("allows a missing recipient when SMTP is off — demo mode sends nothing", () => {
+    expect(findBootEnvErrors({ CONTACT_RECIPIENT: undefined })).toEqual([]);
+  });
+
+  it("reports every broken invariant at once", () => {
+    expect(
+      findBootEnvErrors({ STRIPE_SECRET_KEY: "sk_test_123", SMTP_HOST: "smtp.example.com" }),
+    ).toHaveLength(2);
+  });
+});

--- a/backend/config/bootEnv.ts
+++ b/backend/config/bootEnv.ts
@@ -1,0 +1,48 @@
+/**
+ * Boot-time environment invariants (issues #113, #143).
+ *
+ * Every rule here guards a half-configured state that fails silently at
+ * runtime: the shop keeps answering 200 while payments or customer messages
+ * go nowhere. Better to refuse to boot and name the missing variable.
+ *
+ * Absent optional services are fine — with no Stripe key and no SMTP host the
+ * app runs in demo mode, where nothing is charged and nothing is mailed.
+ */
+
+type Env = Record<string, string | undefined>;
+
+interface EnvInvariant {
+  /** Only checked when this variable is set — it's what turns the service on. */
+  enabledBy: string;
+  requires: string[];
+  /** Why a missing variable is silently destructive, not merely absent. */
+  consequence: string;
+}
+
+const INVARIANTS: EnvInvariant[] = [
+  {
+    enabledBy: "STRIPE_SECRET_KEY",
+    requires: ["STRIPE_WEBHOOK_SECRET", "FRONTEND_URL"],
+    consequence:
+      "payments would succeed while orders are never recorded, and checkout would 500",
+  },
+  {
+    enabledBy: "SMTP_HOST",
+    requires: ["CONTACT_RECIPIENT"],
+    consequence:
+      "contact, return (zwrot) and complaint (reklamacja) submissions would report success to the customer while the notification is rejected for having no recipient",
+  },
+];
+
+/**
+ * @returns one message per broken invariant — empty means safe to boot.
+ */
+export function findBootEnvErrors(env: Env): string[] {
+  return INVARIANTS.flatMap(function checkInvariant({ enabledBy, requires, consequence }) {
+    if (!env[enabledBy]) return [];
+    const missing = requires.filter((name) => !env[name]);
+    if (missing.length === 0) return [];
+    const subject = `${missing.join(" and ")} ${missing.length > 1 ? "are" : "is"}`;
+    return [`${subject} required when ${enabledBy} is set — otherwise ${consequence}.`];
+  });
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,19 +7,20 @@ import Stripe from "stripe";
 import { clerkMiddleware, requireAuth, getAuth } from "@clerk/express";
 import { sendEmail } from "./emails/index.ts";
 import { createApp } from "./app.js";
+import { findBootEnvErrors } from "./config/bootEnv.ts";
+
+// A half-configured service fails silently at runtime — refuse to boot instead.
+const bootEnvErrors = findBootEnvErrors(process.env);
+if (bootEnvErrors.length > 0) {
+  for (const error of bootEnvErrors) console.error(`FATAL: ${error}`);
+  process.exit(1);
+}
 
 const stripe = process.env.STRIPE_SECRET_KEY
   ? new Stripe(process.env.STRIPE_SECRET_KEY)
   : null;
 
 const isDemoMode = !stripe || !process.env.SMTP_HOST;
-
-// When Stripe is live, a missing webhook secret means payments succeed but orders
-// are never recorded, and a missing FRONTEND_URL 500s every checkout. Fail at boot.
-if (stripe && (!process.env.STRIPE_WEBHOOK_SECRET || !process.env.FRONTEND_URL)) {
-  console.error("FATAL: STRIPE_WEBHOOK_SECRET and FRONTEND_URL are required when STRIPE_SECRET_KEY is set.");
-  process.exit(1);
-}
 
 const prisma = new PrismaClient({
   adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),

--- a/backend/routes/forms.js
+++ b/backend/routes/forms.js
@@ -78,17 +78,26 @@ export function createFormsRouter({ prisma, mailer }) {
       const data = Object.fromEntries(fields.map((field) => [field, req.body[field]]));
 
       const record = persist ? await persist(data) : null;
-      try {
-        await mailer.send({
-          to: process.env.CONTACT_RECIPIENT,
-          replyTo: data.email,
-          ...render(data),
-        });
-      } catch (err) {
-        console.error(`Błąd wysyłania emaila (${path}):`, err.message);
-        if (catchPolicy === "fallback-address-500") {
-          return res.status(500).json({ error: FALLBACK_ADDRESS_ERROR });
+      // No recipient means demo mode: the boot check (config/bootEnv.ts) makes
+      // an unset CONTACT_RECIPIENT fatal as soon as SMTP is configured, so the
+      // send would have been skipped by sendEmail anyway. Skipping it here
+      // keeps an undefined recipient out of the mailer contract (issue #143).
+      const recipient = process.env.CONTACT_RECIPIENT;
+      if (recipient) {
+        try {
+          await mailer.send({
+            to: recipient,
+            replyTo: data.email,
+            ...render(data),
+          });
+        } catch (err) {
+          console.error(`Błąd wysyłania emaila (${path}):`, err.message);
+          if (catchPolicy === "fallback-address-500") {
+            return res.status(500).json({ error: FALLBACK_ADDRESS_ERROR });
+          }
         }
+      } else {
+        console.log(`[demo] notification skipped (${path}) — CONTACT_RECIPIENT not set`);
       }
       res.json(record ?? { ok: true });
     });

--- a/backend/test/forms.db.test.ts
+++ b/backend/test/forms.db.test.ts
@@ -4,7 +4,7 @@
  * send mail on anonymous input, so the coverage centers on the guardrails —
  * field validation and the honeypot — plus the capture-mailer contract.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import request from "supertest";
 import { useAppHarness } from "./harness.ts";
 
@@ -133,5 +133,52 @@ describe("POST /reklamacja", () => {
     expect(mailer.sent).toHaveLength(1);
     expect(mailer.sent[0].to).toBe("sklep@test.local");
     expect(mailer.sent[0].html).toContain(validBody.description);
+  });
+});
+
+/**
+ * Demo mode, where SMTP is off too — the boot check (config/bootEnv.ts) makes
+ * this combination impossible once SMTP is configured. The route must not hand
+ * the mailer an undefined recipient (issue #143).
+ */
+describe("without CONTACT_RECIPIENT", () => {
+  let configuredRecipient: string | undefined;
+
+  beforeEach(() => {
+    configuredRecipient = process.env.CONTACT_RECIPIENT;
+    delete process.env.CONTACT_RECIPIENT;
+  });
+
+  afterEach(() => {
+    process.env.CONTACT_RECIPIENT = configuredRecipient;
+  });
+
+  it("stores a contact message and skips the notification", async () => {
+    const { app, mailer } = harness.appAs();
+
+    const res = await request(app).post("/contact").send({
+      name: "Jan Kowalski",
+      email: "jan@example.com",
+      message: "Czy rama 30×40 jest dostępna od ręki?",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mailer.sent).toHaveLength(0);
+    expect(await harness.prisma.contactMessage.count()).toBe(1);
+  });
+
+  it("accepts a return request and skips the notification", async () => {
+    const { app, mailer } = harness.appAs();
+
+    const res = await request(app).post("/zwrot").send({
+      orderNumber: "17",
+      name: "Jan Kowalski",
+      email: "jan@example.com",
+      reason: "Rama nie pasuje do wnętrza",
+      bankAccount: "PL61109010140000071219812874",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mailer.sent).toHaveLength(0);
   });
 });

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: [
+      "config/**/*.test.ts",
       "emails/**/*.test.ts",
       "middleware/**/*.test.ts",
       "orders/**/*.test.ts",

--- a/docs/DEPLOY-DEMO.md
+++ b/docs/DEPLOY-DEMO.md
@@ -163,6 +163,8 @@ All of this happens in **test mode** — check the Stripe dashboard's test-mode 
 
 > **Never paste live keys here.** The demo must only ever see `sk_test_...` / `whsec_...` from test mode. Leave `SMTP_*` unset — the backend logs `[demo] sendEmail skipped` instead of sending order emails.
 
+> **If you ever do set `SMTP_HOST`, you must also set `CONTACT_RECIPIENT`.** Without it every admin notification — new order, contact, zwrot, reklamacja — is rejected for having no recipient while the customer still sees a success message. The backend refuses to boot on that combination and names the missing variable.
+
 ---
 
 ## 7. Smoke-test the demo


### PR DESCRIPTION
## Summary

With SMTP live but `CONTACT_RECIPIENT` unset, nodemailer rejects every admin notification for having no recipient, the public forms' best-effort catch swallows it, and the customer still sees "Wiadomość wysłana". `/zwroty` has no DB fallback, so a statutory-deadline-bearing request is lost outright.

- Boot-time env invariants move out of `index.js` into `backend/config/bootEnv.ts` as a pure, testable table — the existing Stripe rule plus the new SMTP one. Broken invariants print `FATAL: <what is missing and why it matters>` and exit 1.
- The public-form route no longer hands the mailer an undefined recipient; it skips the send when none is configured, which the boot guard restricts to demo mode, where nothing would have been sent anyway.
- The invariant is recorded in `CONTEXT.md`, `backend/.env.example`, and `docs/DEPLOY-DEMO.md`.

Side effect of the extraction: the Stripe boot error now names only the variables actually missing, instead of always naming both.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 104 passing, incl. `config/bootEnv.test.ts` (7 unit cases) and `config/boot.test.ts` (spawns the real `index.js`: exit 1 + `FATAL` when half-configured, `[DEMO MODE]` banner when neither Stripe nor SMTP is set)
- [x] `npm run test:db` — 61 passing, incl. two new `forms.db.test.ts` cases covering the no-recipient route path
- [x] Manual: `CONTACT_RECIPIENT= npx tsx index.js` prints the FATAL line and refuses to start

Closes #143
