### PR TITLE
feat: admin nav shows the signed-in account and can sign out

### DIFF
--- a/src/pages/admin/AdminNav.tsx
+++ b/src/pages/admin/AdminNav.tsx
@@ -1,6 +1,10 @@
 import { NavLink } from "react-router-dom";
+import { UserButton, useUser } from "@clerk/react";
 
 function AdminNav() {
+  const { user } = useUser();
+  const email = user?.primaryEmailAddress?.emailAddress;
+
   return (
     <div className="flex flex-wrap items-center gap-x-2 gap-y-1 w-full bg-near-black font-dm-sans text-warm-white px-4 py-3 sm:px-6 sm:py-5">
       <h2 className="max-sm:basis-full font-dm-sans uppercase tracking-widest text-sm sm:text-xl px-2 py-2 sm:px-4 sm:py-3 mr-auto">
@@ -31,6 +35,30 @@ function AdminNav() {
       >
         Dodaj produkt
       </NavLink>
+      {/* max-sm:ml-auto — below sm the group wraps onto its own row; keep it
+          right-aligned there without disturbing the desktop row */}
+      <div className="flex items-center gap-3 min-h-[44px] max-sm:ml-auto pl-1 sm:pl-3">
+        {email && (
+          <span
+            className="hidden sm:block max-w-[16rem] truncate font-dm-sans text-sm text-warm-white/70"
+            title={email}
+          >
+            {email}
+          </span>
+        )}
+        <UserButton
+          appearance={{
+            elements: {
+              // 28 + 2*8 = a 44 px touch target. The avatar size is pinned
+              // rather than inherited so a Clerk default change can't shrink
+              // the target below 44. Style objects, not Tailwind classes —
+              // classes here lose to Clerk's own rules.
+              userButtonAvatarBox: { width: "28px", height: "28px" },
+              userButtonTrigger: { padding: "8px" },
+            },
+          }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a Clerk `UserButton` to the admin navigation, with the signed-in account's email beside it at `sm` and up
- Trigger padded to a 44 px touch target; avatar size pinned so a Clerk default change can't shrink it below the minimum
- Email collapses into the menu below `sm`, truncates at `16rem`, and the group right-aligns on its wrapped row

No new sign-out wiring — `ClerkProvider` already sets `afterSignOutUrl="/"`. This only adds the control that triggers it.

Clerk's own rules beat Tailwind classes in `appearance.elements`, so the sizing uses style objects. A first attempt with `w-11 h-11` measured 28x28 in the browser.

No `<Show when="signed-in">` guard (unlike the shop navbar): `AdminGuard` returns `null` until Clerk loads and redirects non-admins, so `AdminNav` only mounts for a loaded, signed-in admin.

## Test plan

Measured in a real browser against a signed-in admin session:

- [x] Email visible at 1522x672; contrast 8.59:1 against the dark bar
- [x] Trigger measures 44x44 at both 1522 px and 375 px
- [x] At 375 px the email is hidden and `document.scrollWidth === 375` (no page overflow)
- [x] Sign out from `/admin` lands on `/` with `Clerk.user` null
- [x] `npm run typecheck`, `npm run lint`, `npm test` (228 passing)

Re-measurement of the 44 px target happened before the avatar-size pin was added in review. If Clerk ignores that style object it is a silent no-op and the avatar stays at its 28 px default, so 44 px holds either way.

## Follow-up

`docs/superpowers/specs/2026-07-14-admin-mobile-responsiveness-design.md` describes AdminNav as "zero JS, no new components" — stale after this change.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)