### PR TITLE
fix: show loading skeletons for products on Home and Shop

### DIFF
--- a/src/components/ProductSection.tsx
+++ b/src/components/ProductSection.tsx
@@ -2,7 +2,38 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { formatPln } from "@sznyt/shared";
 import { useCart } from "../hooks/useCart";
+import Skeleton from "./Skeleton";
 import type { ProductSectionProps } from "../types";
+
+/**
+ * Placeholder shown while /products is in flight. Lives next to the real
+ * section so the two layouts stay in step — the panel split, the aspect
+ * ratios and the lg contain-inset are duplicated here on purpose.
+ */
+export function ProductSectionSkeleton({ reverse = false }: { reverse?: boolean }) {
+  return (
+    <section
+      className={`flex flex-col ${reverse ? "md:flex-row-reverse" : "md:flex-row"} lg:h-[calc(100vh-var(--spacing-nav))] lg:max-h-240`}
+    >
+      <div className="relative w-full md:w-1/2 aspect-[4/5] lg:aspect-auto lg:h-full overflow-hidden bg-warm-white">
+        <Skeleton className="absolute inset-0 lg:inset-10" />
+      </div>
+
+      <div className="w-full md:w-1/2 flex items-center bg-warm-white px-6 py-12 md:px-10 lg:px-20">
+        <div className="max-w-md w-full">
+          <Skeleton className="h-3 w-32 mb-4" />
+          <Skeleton className="h-10 md:h-12 lg:h-14 w-3/4 mb-4" />
+          <Skeleton className="h-6 w-2/3 mb-6" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-4/5 mb-8" />
+          <Skeleton className="h-6 w-24 mb-8" />
+          <Skeleton className="h-12 w-48" />
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function ProductSection({
   id,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import ProductSection from "../components/ProductSection";
+import ProductSection, { ProductSectionSkeleton } from "../components/ProductSection";
 import Hero from "../components/Hero";
 import BrandStatement from "../components/BrandStatement";
 import Seo from "../components/Seo";
@@ -6,9 +6,7 @@ import type { Product } from "../types";
 import { useResource } from "../hooks/useResource";
 
 function Home() {
-  // on error products stays empty — page still renders with Hero and BrandStatement
-  const { data } = useResource<Product[]>("/products");
-  const products = data ?? [];
+  const { data: products, error: loadFailed } = useResource<Product[]>("/products");
 
   return (
     <>
@@ -19,20 +17,41 @@ function Home() {
       />
       <Hero />
       <div id="kolekcja" />
-      {products.map((product, index) => (
-        <ProductSection
-          id={product.id}
-          key={product.id}
-          name={product.name}
-          tagline={product.tagline}
-          description={product.description}
-          price={product.price}
-          imageUrl={product.imageUrl}
-          lifestyleImageUrl={product.lifestyleImageUrl}
-          reverse={index % 2 !== 0}
-          stock={product.stock}
-        />
-      ))}
+
+      {/* Three states, never a silently empty collection: the backend can be
+          slow to wake, and a homepage that renders straight through to
+          BrandStatement reads as "shop is broken" rather than "still loading". */}
+      {loadFailed ? (
+        <section className="bg-warm-white px-6 py-16 text-center">
+          <p className="font-dm-sans text-sm text-secondary-text">
+            Nie udało się załadować kolekcji. Odśwież stronę lub zajrzyj do{" "}
+            <a href="/sklep" className="text-near-black underline">
+              sklepu
+            </a>
+            .
+          </p>
+        </section>
+      ) : !products ? (
+        <>
+          <ProductSectionSkeleton />
+          <ProductSectionSkeleton reverse />
+        </>
+      ) : (
+        products.map((product, index) => (
+          <ProductSection
+            id={product.id}
+            key={product.id}
+            name={product.name}
+            tagline={product.tagline}
+            description={product.description}
+            price={product.price}
+            imageUrl={product.imageUrl}
+            lifestyleImageUrl={product.lifestyleImageUrl}
+            reverse={index % 2 !== 0}
+            stock={product.stock}
+          />
+        ))
+      )}
       <BrandStatement />
 
       {/* Why us — 3 columns */}

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -3,7 +3,22 @@ import { Link } from "react-router-dom";
 import { formatPln } from "@sznyt/shared";
 import type { Product } from "../types";
 import Seo from "../components/Seo";
+import Skeleton from "../components/Skeleton";
 import { useResource } from "../hooks/useResource";
+
+// Mirrors ProductCard's box model so the grid doesn't reflow when data lands.
+function ProductCardSkeleton() {
+  return (
+    <div className="block border-b border-borders pb-16 last:border-b-0 last:pb-0 md:border-b-0 md:pb-0">
+      <Skeleton className="aspect-[4/5] w-full" />
+      <div className="pt-4">
+        <Skeleton className="h-7 w-2/3 mb-1" />
+        <Skeleton className="h-5 w-1/2 mb-3" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}
 
 function ProductCard({ product }: { product: Product }) {
   const [hovered, setHovered] = useState(false);
@@ -49,8 +64,7 @@ function ProductCard({ product }: { product: Product }) {
 }
 
 function Shop() {
-  const { data, error: loadFailed } = useResource<Product[]>("/products");
-  const products = data ?? [];
+  const { data: products, error: loadFailed } = useResource<Product[]>("/products");
   const error = loadFailed ? "Nie udało się załadować produktów. Spróbuj ponownie." : null;
 
   return (
@@ -101,6 +115,11 @@ function Shop() {
         <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-y-16 md:gap-y-20 md:gap-x-10">
           {error ? (
             <p className="font-dm-sans text-sm text-red-600 col-span-2">{error}</p>
+          ) : !products ? (
+            <>
+              <ProductCardSkeleton />
+              <ProductCardSkeleton />
+            </>
           ) : (
             products.map((product) => (
               <ProductCard key={product.id} product={product} />


### PR DESCRIPTION
## Summary

`Home` and `Shop` resolved the products resource with `data ?? []`, so a **pending fetch** and an **empty result** rendered identically — a finished-looking page with no products and no sign anything was coming. Every other resource page already distinguishes the two.

This matters on the deployed demo: the backend is on Render's free tier, which spins down after 15 min idle. Measured on a clean 21-minute idle window:

| | TTFB |
|---|---|
| Cold | **44.5 s** |
| Warm | 0.22 s |

For 44 seconds the homepage rendered hero → brand statement → "why us" with an empty collection. It read as a broken shop rather than a loading one.

## Changes

- `ProductSection.tsx` — new exported `ProductSectionSkeleton`, co-located with the component it mirrors so the panel split, aspect ratios and `lg` contain-inset stay in step.
- `Home.tsx` — loading renders two alternating skeleton sections; a load failure now surfaces a message instead of silently rendering through to `BrandStatement`.
- `Shop.tsx` — local `ProductCardSkeleton`; loading renders two skeleton cards in the grid.

Deliberately **not** adding a `loading` flag to `useResource`: six pages (`ProductDetail`, `MyOrders`, `AdminOrders`, `AdminProducts`, `AdminOrderDetail`, `RevenueBanner`) already use the convention *check `error` first, then null data means loading*. `Home` and `Shop` were the two that never adopted it. Following it kept this to 3 files instead of 8 call sites.

## Test plan

Verified by pointing Vite at a stub that holds the socket open and never replies, pinning both pages in their loading state (no Postgres or seed needed). Screenshotted at 1522×672 per the laptop-viewport invariant.

- [x] Loading — Home 18 pulsing elements (alternating sections), Shop 8 (2 grid cards)
- [x] Loaded — 0 skeletons both pages, products render, grid positions identical to the skeleton (no reflow)
- [x] Error (stub 500) — Home "Nie udało się załadować kolekcji…", Shop "Nie udało się załadować produktów…"
- [x] `npm run lint`, `npm run typecheck`, `npm run build`, `npm test` (228 passed)

Note: the Render free-tier cold start itself is infrastructure, fixed separately by upgrading the instance to Starter. This PR ensures the wake looks like loading rather than breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)