### PR TITLE
chore: declare the Render starter plan in the blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,11 @@ services:
   - type: web
     name: sznyt-design-backend
     runtime: node
-    plan: free
+    # Starter, not free: free web services spin down after 15 min without
+    # inbound traffic and take ~45 s to wake, which the demo's first visitor
+    # of the day always pays. Must match the dashboard instance type — if
+    # this says free, a Blueprint sync silently downgrades the paid service.
+    plan: starter
     rootDir: backend
     buildCommand: npm install && npm run build
     startCommand: npm start


### PR DESCRIPTION
## Summary

The dashboard instance type for `sznyt-design-backend` was upgraded to **Starter** so the demo backend stops spinning down, but `render.yaml` still declared `plan: free`. The service is Blueprint-managed (`docs/DEPLOY-DEMO.md:56`), so a later sync would have silently reverted the paid instance back to Free — paying while still sleeping.

This makes the repo agree with the dashboard.

## Why it mattered

Measured on a clean 21-minute idle window before the upgrade:

| | TTFB |
|---|---|
| Cold | **44.5 s** |
| Warm | 0.22 s |

Render spins free web services down after 15 min without inbound traffic and takes [about a minute](https://render.com/docs/free) to wake. The demo's first visitor of the day always paid it.

Pairs with #147, which made that wake render as a loading state rather than an empty shop.

## Test plan

- [x] `starter` verified as a valid lowercase `plan` value in the [Blueprint spec](https://render.com/docs/blueprint-spec)
- [ ] After merge: confirm Render's Blueprint sync succeeds and the service stays on Starter
- [ ] After merge: 25 min idle, then load the demo — expect ~0.2 s cold instead of 44.5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)