### PR TITLE
fix: stop cropping frame photos in cart and order thumbnails

### DIFF
--- a/src/orders/OrderCard.tsx
+++ b/src/orders/OrderCard.tsx
@@ -143,7 +143,7 @@ function ListItem({ order }: { order: Order }) {
         <div className="flex flex-col gap-2">
           {order.items.map((item) => (
             <div key={item.id} className="flex items-center gap-3">
-              <ItemThumb item={item} sizeClass="w-10 h-10" />
+              <ItemThumb item={item} sizeClass="w-10 aspect-[4/5]" />
               <p className="font-dm-sans text-sm text-secondary-text">
                 {item.product?.name ?? DELETED_PRODUCT_NAME}{" "}
                 <span className="text-near-black">× {item.quantity}</span>
@@ -208,7 +208,7 @@ function DetailBody({ order }: { order: Order }) {
       <div className="flex flex-col divide-y divide-borders mb-12">
         {order.items?.map((item) => (
           <div key={item.id} className="flex gap-4 md:gap-6 py-6 items-center">
-            <ItemThumb item={item} sizeClass="w-14 h-14 md:w-20 md:h-20" />
+            <ItemThumb item={item} sizeClass="w-14 md:w-20 aspect-[4/5]" />
             <div className="flex-1 min-w-0">
               <p className="font-cormorant text-lg md:text-xl text-near-black font-light">
                 {item.product?.name ?? DELETED_PRODUCT_NAME}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -124,7 +124,7 @@ function Cart() {
           {items.map((item) => (
             <div key={item.id} className="flex gap-4 py-6 md:py-8">
               <div
-                className="w-16 h-16 md:w-24 md:h-24 bg-cover bg-center shrink-0 mt-1"
+                className="w-16 md:w-24 aspect-[4/5] bg-cover bg-center shrink-0 mt-1"
                 style={{ backgroundImage: `url(${item.imageUrl})` }}
               />
               <div className="flex-1 min-w-0 flex flex-col gap-3">

--- a/src/pages/admin/AdminOrderDetail.tsx
+++ b/src/pages/admin/AdminOrderDetail.tsx
@@ -30,7 +30,7 @@ function SectionLabel({ children }: { children: string }) {
 function LineItemRow({ item }: { item: OrderItem }) {
   return (
     <div className="flex items-center gap-3 py-3">
-      <ItemThumb item={item} sizeClass="w-12 h-12" />
+      <ItemThumb item={item} sizeClass="w-12 aspect-[4/5]" />
       <div className="flex-1 min-w-0">
         <p className="font-medium truncate">{item.product?.name ?? DELETED_PRODUCT_NAME}</p>
         <p className="text-xs text-gray-500">


### PR DESCRIPTION
## Summary

Cart thumbnails were locked to a 1:1 box (`w-16 h-16 md:w-24 md:h-24`) with `bg-cover`. Every product photo is authored at 848×1060 — exactly 4:5 — so filling a square scaled to width and cropped 20% of the height, clipping the top and bottom of the frame. Both products showed it identically because both photos share the ratio.

Fixed by giving the container the asset's own ratio (`aspect-[4/5]`) rather than switching to `contain`, which would have letterboxed a grey photo edge against the warm-white page. This also makes the cart consistent with `Shop.tsx` and `ProductSection.tsx`, which already use `aspect-[4/5]`.

The same square crop existed in the order-history and admin order-detail thumbnails (shared `ItemThumb`), so those are fixed too.

## Test plan

- [x] `tsc -b --noEmit` clean
- [x] `eslint` clean on the three changed files
- [x] Cart verified in-browser at 1522×672 — both thumbnails measure 96×120 (ratio 0.800), matching the source; full frame visible, no crop, no letterbox
- [ ] Order history (`/zamowienia`) and `/admin` order detail — same one-line change to shared `ItemThumb`, but behind Clerk login and not runtime-verified; worth an eyeball when next logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)