### PR TITLE
docs: drop the cold-start warning from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Worth noticing while you're in there:
 - **npm-workspaces monorepo** with shared TypeScript types across the React frontend and Express backend — one definition of `Product`/`Order` on both sides of the API boundary.
 - **Transactional email module** — order confirmation, shipping notification, contact form; in the demo SMTP is intentionally unset, so the backend logs `[demo] sendEmail skipped` instead of sending.
 
-Demo infra: Vercel (frontend) + Render (backend) + Neon (Postgres) + Clerk dev + Stripe test mode — $0/month. Runbook: `docs/DEPLOY-DEMO.md`. First request may take ~30 s (Render free tier waking up).
+Demo infra: Vercel (frontend) + Render Starter (backend) + Neon (Postgres) + Clerk dev + Stripe test mode. Runbook: `docs/DEPLOY-DEMO.md`. The backend runs on a paid instance so it doesn't spin down — the demo is warm when you open it.
 
 ## Tech stack
 
@@ -45,7 +45,7 @@ Demo infra: Vercel (frontend) + Render (backend) + Neon (Postgres) + Clerk dev +
 | Auth | Clerk | Hosted; saves writing session/password infrastructure |
 | Payments | Stripe Checkout | Hosted = no PCI scope; webhook is the source of truth |
 | Email | Nodemailer + hosting-provider SMTP | Transactional volume too low to justify a paid provider |
-| Hosting | Vercel (frontend) + Render/Railway (backend) + Neon (DB) | Vercel free tier for the SPA; Render free for demo backend |
+| Hosting | Vercel (frontend) + Render/Railway (backend) + Neon (DB) | Vercel free tier for the SPA; Render Starter for the demo backend so it never spins down |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

The demo backend moved from Render Free to Starter (#148, #149), so it no longer spins down. The README hadn't caught up:

- Removed "First request may take ~30 s (Render free tier waking up)"
- Removed the "$0/month" demo-infra claim (Starter is a paid instance)
- Tech-stack Hosting row now says Render Starter, "so it never spins down"

`docs/DEPLOY-DEMO.md` was already correct — this was the last stale mention.

## Test plan

- [x] Grepped the repo for remaining `~30 s` / `free tier` / `$0` claims about the backend
- [ ] README renders correctly on GitHub after merge