### PR TITLE
chore: ignore .vercel CLI artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ playwright-report/
 .claude/statsig/
 .claude/history.jsonl
 .claude/ide/
+.vercel


### PR DESCRIPTION
## Summary
- Ignore the `.vercel/` directory the Vercel CLI writes into the project root on link/deploy.

## Notes
Deliberately no `.env*` rule — `.env` is already covered on line 26 and `.env.local`
by `*.local` on line 13, and `.env*` would additionally shadow the tracked
`.env.example` / `backend/.env.example` templates.

## Test plan
- [x] `git check-ignore` confirms `.env`, `.env.local`, `.vercel` are ignored
- [x] `.env.example` and `backend/.env.example` no longer matched by any rule